### PR TITLE
Set maxZoom from attrs

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -22,6 +22,11 @@ leafletDirective.directive("leaflet", ["$http", "$log", function ($http, $log) {
                 scope.map = map;
             }
 
+            // Set maxZoom from attrs
+            if (attrs.maxzoom){
+                scope.maxZoom = parseInt(attrs.maxzoom)
+            }
+
             // Set initial view
             map.setView([0, 0], 1);
 


### PR DESCRIPTION
`scope.maxZoom` doesn't seem to work, and this solution allows settings maxzoom like

``` html
<leaflet maxzoom="18" ...></leaflet>
```
