### PR TITLE
Call setView only if center is valid

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -58,7 +58,9 @@ leafletDirective.directive("leaflet", ["$http", "$log", function ($http, $log) {
                 });
 
                 scope.$watch("center", function (center, oldValue) {
-                    map.setView([center.lat, center.lng], center.zoom);
+                    if(center.lat && center.lng && center.zoom){
+                        map.setView([center.lat, center.lng], center.zoom);
+                    }
                 }, true);
             }
 


### PR DESCRIPTION
Since there are some minor issues with timing when calling setView too frequently one way to work with that is setting the center.let/lng to undefined first (and skip calling setView) and then call only when set to proper values.
