### PR TITLE
Fixed bug where uninitialized center causes map dragging to fail

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -95,7 +95,7 @@ leafletDirective.directive("leaflet", ["$http", "$log", "$parse", function ($htt
             var centerModel = {
                 lat:$parse("center.lat"),
                 lng:$parse("center.lng"),
-                 zoom:$parse("center.zoom")
+                zoom:$parse("center.zoom")
             };
         
             function setupCenter() {


### PR DESCRIPTION
I encountered this bug in Chrome 25.0.1364.160 on Ubuntu 12.04 in the simple example demo here: http://tombatossals.github.io/angular-leaflet-directive/

Clicking and dragging the map throws a bunch of TypeErrors because the controller in this example never initialized a map center. Furthermore, after you zoom once you can no longer click and drag the map.

To fix, it now warns if center is undefined and uses $parse(...).assign to safely manipulate $scope.center
