### PR TITLE
Map center update now happens on moveend instead of dragend

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -249,24 +249,12 @@ leafletDirective.directive('leaflet', [
                     }
                 }, true);
 
-                map.on("dragend", function (/* event */) {
+                map.on("moveend", function (/* event */) {
                     $scope.safeApply(function (scope) {
                         centerModel.lat.assign(scope, map.getCenter().lat);
                         centerModel.lng.assign(scope, map.getCenter().lng);
+                        centerModel.zoom.assign(scope, map.getZoom());
                     });
-                });
-
-                map.on("zoomend", function (/* event */) {
-                    if(angular.isUndefined($scope.center)){
-                        $log.warn("[AngularJS - Leaflet] 'center' is undefined in the current scope, did you forget to initialize it?");
-                    }
-                    if (angular.isUndefined($scope.center) || $scope.center.zoom !== map.getZoom()) {
-                        $scope.safeApply(function (s) {
-                            centerModel.zoom.assign(s, map.getZoom());
-                            centerModel.lat.assign(s, map.getCenter().lat);
-                            centerModel.lng.assign(s, map.getCenter().lng);
-                        });
-                    }
                 });
             }
 


### PR DESCRIPTION
Using `dragend` is insufficient when the map has inertia movement on.

If the map is dragged with force, the center isn't updated to the final resting place properly. Using `moveend` resolves this. This also removes the need for the separate `zoomend` watcher as `moveend` covers all movement.

In this request I removed `zoomend` as the `moveend` seems to cover both cases well. The `zoomend` had much more in it than the old `dragend` and I want to make sure that I haven't removed anything important here. Feedback encouraged. I can make any needed changes.
