### PR TITLE
Support for marker events

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -376,6 +376,18 @@ leafletDirective.directive('leaflet', [
                     }
                 });
 
+                // Set up marker events
+                // Pass original marker name with the event data for easier reference
+                var eventData = {
+                    name: scope_watch_name.replace('markers.', '')
+                };
+
+                if ( typeof(marker_data.events) == 'object'){
+                    for (var bind_to  in marker_data.events){
+                        marker.on(bind_to, marker_data.events[bind_to], eventData);
+                    }
+                }
+
                 var clearWatch = $scope.$watch(scope_watch_name, function (data, old_data) {
                     if (!data) {
                         map.removeLayer(marker);

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -265,15 +265,15 @@ describe('Directive: leaflet', function() {
         expect(map.getBounds().equals(bounds)).toEqual(true);
     });
 
-    it('shold load event object from the parent scope',function(){
+    it('should load event object from the parent scope',function(){
         angular.extend($rootScope, {
             events: {
-            dblclick: function(){
-                return true;
-            },
-            click: function(){
-                return true;
-            } 
+                dblclick: function(){
+                    return true;
+                },
+                click: function(){
+                    return true;
+                } 
             }
         });
 
@@ -284,5 +284,24 @@ describe('Directive: leaflet', function() {
         expect(events.click[0].action()).toEqual(true);
         expect(events.click[0].action()).toEqual(true);
 
+    });
+
+    it('should attach events to markers', function() {
+        var main_marker = {
+            lat: 0.966,
+            lng: 2.02,
+            events: {
+                click: function() {
+                    return true;
+                }
+            }
+        };
+        angular.extend($rootScope, { marker: main_marker });
+        var element = angular.element('<leaflet marker="marker" testing="testing"></leaflet>');
+        element = $compile(element)($rootScope);
+        var map = element.scope().leaflet.map;
+        var leafletMainMarkerEvents = element.scope().leaflet.marker._leaflet_events;
+
+        expect(leafletMainMarkerEvents.click[0].action()).toEqual(true);
     });
 });


### PR DESCRIPTION
As mentioned in #74, I am in need of marker events. I’ve added marker events in the same fashion that events are being added to the map in `setupEvents()`.

Events can be attached on a per marker basis by attaching an `events` object with callback functions.

```
var main_marker = {
    lat: 0.966,
    lng: 2.02,
    events: {
        click: function(e) {
            /* Act on event */
        }
    }
};
```

Within the callback, `this` contains an object with the original name given to the marker to allow you to reference the object of markers within the controller. If there’s a better way to do this, please let me know.

Currently no events are broadcasted to the root scope so these event callbacks are really only available to the current scope. I can forsee cases where this is an issue, but there are many cases where it isn’t.

Any feedback and suggestions greatly appreciated!
