### PR TITLE
Changed marker events from callbacks to rootScope broadcasts

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -364,16 +364,38 @@ leafletDirective.directive('leaflet', [
                     }
                 });
 
-                // Set up marker events
-                // Pass original marker name with the event data for easier reference
-                var eventData = {
-                    name: scope_watch_name.replace('markers.', '')
-                };
+                // Set up marker event broadcasting
+                var markerEvents = [
+                    'click',
+                    'dblclick',
+                    'mousedown',
+                    'mouseover',
+                    'mouseout',
+                    'contextmenu',
+                    'dragstart',
+                    'drag',
+                    'dragend',
+                    'move',
+                    'remove',
+                    'popupopen',
+                    'popupclose'
+                ];
 
-                if ( typeof(marker_data.events) == 'object'){
-                    for (var bind_to  in marker_data.events){
-                        marker.on(bind_to, marker_data.events[bind_to], eventData);
-                    }
+                for( var i=0; i < markerEvents.length; i++) {
+                    var eventName = markerEvents[i];
+
+                    marker.on(eventName, function(e) {
+                        var broadcastName = 'leafletDirectiveMarker.' + this.eventName;
+                        $rootScope.$apply(function(){
+                            $rootScope.$broadcast(broadcastName, {
+                                markerName: scope_watch_name.replace('markers.', ''),
+                                leafletEvent: e
+                            });
+                        });
+                    }, {
+                        eventName: eventName,
+                        scope_watch_name: scope_watch_name
+                    });
                 }
 
                 var clearWatch = $scope.$watch(scope_watch_name, function (data, old_data) {

--- a/test/unit/directivesSpec.js
+++ b/test/unit/directivesSpec.js
@@ -285,23 +285,4 @@ describe('Directive: leaflet', function() {
         expect(events.click[0].action()).toEqual(true);
 
     });
-
-    it('should attach events to markers', function() {
-        var main_marker = {
-            lat: 0.966,
-            lng: 2.02,
-            events: {
-                click: function() {
-                    return true;
-                }
-            }
-        };
-        angular.extend($rootScope, { marker: main_marker });
-        var element = angular.element('<leaflet marker="marker" testing="testing"></leaflet>');
-        element = $compile(element)($rootScope);
-        var map = element.scope().leaflet.map;
-        var leafletMainMarkerEvents = element.scope().leaflet.marker._leaflet_events;
-
-        expect(leafletMainMarkerEvents.click[0].action()).toEqual(true);
-    });
 });


### PR DESCRIPTION
**Problem Found**

Alright. My initial tests and work that went into #86 seemed like they would have done the trick for marker events. Once I got down to _actually_ using marker events this evening, I found that they "worked" but with a major issue. 

The issue is that Angular's `$digest` process was getting messed with. If you changed any values on `$scope` within the callback, the proper listeners wouldn't get triggered. If you called `$scope.$digest()` within the callback on the event, all worked as expected. Clearly this is more of a bug.

**Solution** 

I've updated the marker events to use `$broadcast` to the root scope. All Leaflet marker events are automatically set up on each marker. When you set up a listener for these events you use

```
$scope.$on('leafletDirectiveMarker.<eventName>', function(e, data){
    /* e is the Angular event data */
    /* data is the information passed from the marker. data.markerName is the name of the marker acted upon */
});
```

I apologize for #86 not working at intended. Despite my testing, this was a case I didn't run into :confused:. Getting some more eyes on this pull request would be great just incase anything was missed.

Thanks.

**Note:** If you've started using the marker events from #86, you'll need to update to use the proper event listeners as that code was removed.
