### PR TITLE
Cleaned up marker events removing legacy function while preserving backwards compatibility.

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -323,18 +323,9 @@ leafletDirective.directive('leaflet', [
                     return;
                 }
 
-                function genMultiMarkersClickCallback(m_name) {
-                    return function(e) {
-                        $rootScope.$apply(function() {
-                            $rootScope.$broadcast('leafletDirectiveMarkersClick', m_name);
-                        });
-                    };
-                }
-
                 for (var name in $scope.markers) {
                     markers[name] = createMarker(
                             'markers.'+name, $scope.markers[name], map);
-                    markers[name].on('click', genMultiMarkersClickCallback(name));
                 }
 
                 $scope.$watch('markers', function(newMarkers) {
@@ -349,7 +340,6 @@ leafletDirective.directive('leaflet', [
                         if (markers[new_name] === undefined) {
                             markers[new_name] = createMarker(
                                 'markers.'+new_name, newMarkers[new_name], map);
-                            markers[new_name].on('click', genMultiMarkersClickCallback(new_name));
                         }
                     }
                 }, true);


### PR DESCRIPTION
Did some clean up work on the marker events and added support for the click events to broadcast "leafletDirectiveMarkersClick" as well as the new format of "leafletDirectiveMarker.click" for backwards compatibility.

Opted to leave all this in the createMarker function so that it was in one place and guaranteed to be applied to every marker added to the map regardless of origin or time of addition.

Removed `genMultiMarkersClickCallback` calls in the clean up as they weren't necessary and were causing duplicate events to be attached to markers when used with the new system.

Think that's finally it for marker events!! :smile: 

**Note:** This PR was rebased off of master for easier merging but there is current an issue in master as described in #89
