### PR TITLE
Fixed legacy marker click broadcast which prevented new event from firing

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -391,14 +391,14 @@ leafletDirective.directive('leaflet', [
                             $rootScope.$apply(function(){
                                 $rootScope.$broadcast('leafletDirectiveMarkersClick', markerName);
                             });
-                        } else {
-                            $rootScope.$apply(function(){
-                                $rootScope.$broadcast(broadcastName, {
-                                    markerName: markerName,
-                                    leafletEvent: e
-                                });
-                            });
                         }
+
+                        $rootScope.$apply(function(){
+                            $rootScope.$broadcast(broadcastName, {
+                                markerName: markerName,
+                                leafletEvent: e
+                            });
+                        });
                     }, {
                         eventName: eventName,
                         scope_watch_name: scope_watch_name


### PR DESCRIPTION
Had a misplaced if/else which was preventing the new click events from firing.

Now **both** the new click event name and the legacy one are firing on marker click.
