### PR TITLE
Support for map event broadcasting

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -125,60 +125,65 @@ leafletDirective.directive('leaflet', [
             * All events listed at http://leafletjs.com/reference.html#map-events are supported
             */
             function setupMapEventBroadcasting() {
-                var mapEvents = [
-                    'click',
-                    'dblclick',
-                    'mousedown',
-                    'mouseup',
-                    'mouseover',
-                    'mouseout',
-                    'mousemove',
-                    'contextmenu',
-                    'focus',
-                    'blur',
-                    'preclick',
-                    'load',
-                    'unload',
-                    'viewreset',
-                    'movestart',
-                    'move',
-                    'moveend',
-                    'dragstart',
-                    'drag',
-                    'dragend',
-                    'zoomstart',
-                    'zoomend',
-                    'zoomlevelschange',
-                    'resize',
-                    'autopanstart',
-                    'layeradd',
-                    'layerremove',
-                    'baselayerchange',
-                    'overlayadd',
-                    'overlayremove',
-                    'locationfound',
-                    'locationerror',
-                    'popupopen',
-                    'popupclose'
-                ];
 
-                for (var i = 0; i < mapEvents.length; i++) {
-                    var eventName = mapEvents[i];
+              function genDispatchMapEvent(eventName) {
+                return function(e) {
+                  // Put together broadcast name for use in safeApply
+                  var broadcastName = 'leafletDirectiveMap.' + eventName;
 
-                    map.on(eventName, function(e) {
-                        // Put together broadcast name for use in safeApply
-                        var broadcastName = 'leafletDirectiveMap.' + this.eventName;
-
-                        // Safely broadcast the event
-                        safeApply(function(scope) {
-                            $rootScope.$broadcast(broadcastName, {
-                                leafletEvent: e
-                            });
-                        });
-                    }, {
-                        eventName: eventName
+                  // Safely broadcast the event
+                  safeApply(function(scope) {
+                    $rootScope.$broadcast(broadcastName, {
+                      leafletEvent: e
                     });
-                }
+                  });
+                };
+              }
+
+              var mapEvents = [
+                'click',
+                'dblclick',
+                'mousedown',
+                'mouseup',
+                'mouseover',
+                'mouseout',
+                'mousemove',
+                'contextmenu',
+                'focus',
+                'blur',
+                'preclick',
+                'load',
+                'unload',
+                'viewreset',
+                'movestart',
+                'move',
+                'moveend',
+                'dragstart',
+                'drag',
+                'dragend',
+                'zoomstart',
+                'zoomend',
+                'zoomlevelschange',
+                'resize',
+                'autopanstart',
+                'layeradd',
+                'layerremove',
+                'baselayerchange',
+                'overlayadd',
+                'overlayremove',
+                'locationfound',
+                'locationerror',
+                'popupopen',
+                'popupclose'
+              ];
+
+              for (var i = 0; i < mapEvents.length; i++) {
+                var eventName = mapEvents[i];
+
+                map.on(eventName, genDispatchMapEvent(eventName), {
+                  eventName: eventName
+                });
+              }
             }
 
             /*


### PR DESCRIPTION
## Overview

**Map events for all!!**

:tada: 

This pull request adds support for all [Leaflet Map Events](http://leafletjs.com/reference.html#map-events) which are broadcasted on `rootScope`.
## Setting up listeners

Event listeners follow the similar naming convention as marker events with the format `leafletDirectiveMap.<leaflet event name>`.
### Example

```
$scope.$on('leafletDirectiveMap.click', function(e, args) {
    // Args includes the original leaflet event
});
```
