### PR TITLE
add support of custom controls

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -66,7 +66,8 @@ leafletDirective.directive('leaflet', [
             paths: '=paths',
             tiles: '=tiles',
             events: '=events',
-            layers: '=layers'
+            layers: '=layers',
+            customControls: '=customControls'
         },
         template: '<div class="angular-leaflet-map"></div>',
         link: function ($scope, element, attrs /*, ctrl */) {
@@ -98,6 +99,7 @@ leafletDirective.directive('leaflet', [
             $scope.leaflet.map = !!attrs.testing ? map : str_inspect_hint;
 
             setupControls();
+            setupCustomControls();
             setupLayers();
             setupCenter();
             setupMaxBounds();
@@ -930,6 +932,16 @@ leafletDirective.directive('leaflet', [
                 //@TODO add document for this option  11.08 2013 (houqp)
                 if ($scope.defaults && $scope.defaults.zoomControlPosition) {
                     map.zoomControl.setPosition($scope.defaults.zoomControlPosition);
+                }
+            }
+
+            function setupCustomControls() {
+                if (!$scope.customControls) {
+                    return;
+                }
+
+                for(var i = 0, count = $scope.customControls.length; i < count; i++) {
+                    map.addControl(new $scope.customControls[i]());
                 }
             }
         }


### PR DESCRIPTION
# Usage
## Partial

``` html
<leaflet markers="markers" center="center" events="events" custom-controls="myCustomControls">
</leaflet>
```
## Controller logic

``` javascript
//setup custom controls
    $scope.myCustomControls = [];

    var MyControl = L.Control.extend({
        options: {
            position: 'bottomleft'
        },

        onAdd: function (map) {
            var className = 'leaflet-control-my-location',
                container = L.DomUtil.create('div', className + ' leaflet-bar');

            // add here MyControl view & logic

            return container;
        }
    });

    $scope.myCustomControls.push(MyControl);
```

more about custom controls http://leafletjs.com/reference.html#icontrol
