### PR TITLE
to catch 'load' event of Leaflet

### DIFF
--- a/src/angular-leaflet-directive.js
+++ b/src/angular-leaflet-directive.js
@@ -209,9 +209,10 @@ leafletDirective.directive('leaflet', [
             });
             var layers = null;
 
-            map.setView([defaults.center.lat, defaults.center.lng], defaults.center.zoom);
             $scope.leaflet.map = !!attrs.testing ? map : str_inspect_hint;
 
+            setupMapEventCallbacks();
+            setupMapEventBroadcasting();
             setupControls();
             setupCustomControls();
             setupLayers();
@@ -222,8 +223,6 @@ leafletDirective.directive('leaflet', [
             setupMarkers();
             setupPaths();
             setupLegend();
-            setupMapEventBroadcasting();
-            setupMapEventCallbacks();
             setupGeojson();
 
             // use of leafletDirectiveSetMap event is not encouraged. only use


### PR DESCRIPTION
'load' event trigger after map.setView() http://leafletjs.com/reference.html#map-load that has place in setupCenter() function. 

As well line before all setup*() functions:

``` javascript
map.setView([defaults.center.lat, defaults.center.lng], defaults.center.zoom);
```

has duplicated in setupCenter() function, so no any reason for it.

So without that fix there is no any possibilities to catch 'load' event because it triggers before we have set all your event handlers.
