### PR TITLE
Fix issue for paths directive.

### DIFF
--- a/src/directives/paths.js
+++ b/src/directives/paths.js
@@ -22,6 +22,8 @@ angular.module("leaflet-directive").directive('paths', function ($log, leafletDa
 
                 var leafletPaths = {};
                 leafletData.setPaths(leafletPaths, attrs.id);
+                
+                scope.paths = paths;
 
                 scope.$watch("paths", function (newPaths) {
                     // Create the new paths


### PR DESCRIPTION
Here is demo:
http://jsfiddle.net/49xVW/

Look on this what is in attribute paths and what map display.
Map read only default paths from `$scope`. It ignore attribute variables.

I also write about this in issue #229
