### PR TITLE
Updated bower.json - because the dependencies for leaflet.markerclustere...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "angular-animate": "1.2.x",
     "angular-mocks": "1.2.x",
     "leaflet-dist": "0.7.x",
-    "leaflet.markerclusterer": "0.4",
+    "leaflet.markerclusterer": "",
     "leaflet.draw": "0.2.2",
     "Leaflet.label": "0.2.1",
     "Leaflet.awesome-markers": "*",


### PR DESCRIPTION
"bower install" no longer works because the "leaflet.markerclusterer" project doesn't have any tags (I'm not sure if the tags were removed, but there is only a single branch: master, so the bower install portion of this project failed until I removed the 0.4 version from the bower.json).

I've also created a 0.7.3 version of this project in my fork for reference.
