### PR TITLE
Added ignore to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "javascript",
     "directive",
     "leaflet"
-  ]
+  ],
   "main": [
     "dist/angular-leaflet-directive.js",
     "dist/angular-leaflet-directive.min.js"


### PR DESCRIPTION
So that only distribution files get distributed using Bower install, rather then the whole Git folder.
More information: https://github.com/bower/bower.json-spec
