### PR TITLE
Fix update loop

### DIFF
--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -52,11 +52,11 @@ angular.module("leaflet-directive").directive('center', function ($log, $parse, 
                     }
 
                     map.setView([center.lat, center.lng], center.zoom);
-                    changingModel = false;
                 }, true);
 
                 map.on("moveend", function(/* event */) {
                     if (changingModel) {
+                        changingModel = false;
                         return;
                     }
 


### PR DESCRIPTION
Only reset the `changingModel` flag after the `moveend` event has fired. This event should fire for both `map.setView()` and `map.locate()`. Before this change, the `changeModel` flag would not be reset for a `map.locate()` call and in other cases. It also appears that the `moveend` event fires async which means that `changeModel` was reset to `false` before the `moveend` event actually fired. Fix for #254.
