### PR TITLE
added support for wmts layers

### DIFF
--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -17,6 +17,12 @@ angular.module("leaflet-directive").factory('leafletLayerHelpers', function ($ro
                 return L.tileLayer.wms(params.url, params.options);
             }
         },
+        wmts: {
+            mustHaveUrl: true,
+            createLayer: function(params) {
+                return L.tileLayer.wmts(params.url, params.options);
+            }
+        },
         wfs: {
             mustHaveUrl: true,
             mustHaveLayer : true,


### PR DESCRIPTION
you need to add a dependency to https://github.com/mylen/leaflet.TileLayer.WMTS in order to make it work.
You can use it like that:

``` javascript
    angular.extend($scope, {
        lyon: {
            lat: 45.7071,
            lng: 4.9625,
            zoom: 12
        },
        layers: {
            baselayers: {
                wmts: {
                    name: 'IGN',
                    url: "http://wxs.ign.fr/" + "YOURKEY" + "/geoportail/wmts",
                    type: 'wmts',
                    layerParams: {
                        layer: "GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-EXPRESS.STANDARD",
                        style: 'normal',
                        tilematrixSet: "PM",
                        format: 'image/jpeg',
                        attribution: "&copy; <a href='http://www.ign.fr'>IGN</a>"
                    }                    
                }
            }
        }
    });
```
