### PR TITLE
supporto for click mobile

### DIFF
--- a/src/directives/geojson.js
+++ b/src/directives/geojson.js
@@ -48,6 +48,7 @@ angular.module("leaflet-directive").directive('geojson', function ($log, $rootSc
                                 },
                                 click: function(e) {
                                     safeApply(leafletScope, function() {
+                                        geojson.selected = feature;
                                         $rootScope.$broadcast('leafletDirectiveMap.geojsonClick', geojson.selected, e);
                                     });
                                 }


### PR DESCRIPTION
geojson.selected = feature must be applied also in click event, because mouseover event isn't triggered in mobile browser
