### PR TITLE
trailing commas fix

### DIFF
--- a/src/services/leafletHelpers.js
+++ b/src/services/leafletHelpers.js
@@ -202,7 +202,7 @@ angular.module("leaflet-directive").factory('leafletHelpers', function ($q, $log
                 } else {
                     return false;
                 }
-            },
+            }
         },
         AGSLayerPlugin: {
             isLoaded: function() {
@@ -214,7 +214,7 @@ angular.module("leaflet-directive").factory('leafletHelpers', function ($q, $log
                 } else {
                     return false;
                 }
-            },
+            }
         },
         YandexLayerPlugin: {
             isLoaded: function() {
@@ -238,7 +238,7 @@ angular.module("leaflet-directive").factory('leafletHelpers', function ($q, $log
 				} else {
 					return false;
 				}
-			},
+			}
         },
         GeoJSONPlugin: {
             isLoaded: function(){


### PR DESCRIPTION
IE8 (and below) will parse trailing commas in array and object literals incorrectly
