### PR TITLE
Solves issue #320

### DIFF
--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -158,7 +158,7 @@ angular.module("leaflet-directive").factory('leafletMarkersHelpers', function ($
                     }
                 }
 
-                if (isString(markerData.layer) && (isDefined(oldMarkerData.layer) || oldMarkerData.layer !== markerData.layer)) {
+                if (isString(markerData.layer) && (isDefined(oldMarkerData.layer) && (oldMarkerData.layer !== markerData.layer))) {
                     // If it was on a layer group we have to remove it
                     if (isString(oldMarkerData.layer) && isDefined(layers.overlays[oldMarkerData.layer]) && layers.overlays[oldMarkerData.layer].hasLayer(marker)) {
                         layers.overlays[oldMarkerData.layer].removeLayer(marker);


### PR DESCRIPTION
Solves issue #320. A more accurate detection of what has happened to the marker was needed because for a MarkerClusterLayer a marker can't be moved, only deleted a added again with its location updated.
Also corrects a little bug while evaluating condition if a marker change its layer.
