### PR TITLE
Update Protractor config to use Selenium v2.41.0

### DIFF
--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
   // chromeDriver)
 
   // The location of the selenium standalone server .jar file.
-  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.40.0.jar',
+  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.41.0.jar',
   // The port to start the selenium server on, or null if the server should
   // find its own unused port.
   seleniumPort: null,


### PR DESCRIPTION
The latest build of Protractor ships with Selenium version 2.41.0. This
commit updates `test/protractor.conf.js` to use this version.

Please note that Protractor tests are currently not passing with
Selenium version 2.41.0. I'm not sure if this condition existed before
updating.
