### PR TITLE
Fix to display paths loaded from back-end

### DIFF
--- a/src/directives/paths.js
+++ b/src/directives/paths.js
@@ -38,6 +38,7 @@ angular.module("leaflet-directive").directive('paths', function ($log, leafletDa
                 leafletScope.$watch("paths", function (newPaths) {
                     // Create the new paths
                     for (var newName in newPaths) {
+                        if (newName.search('\\$') === 0) continue;
                         if (newName.search("-") !== -1) {
                             $log.error('[AngularJS - Leaflet] The path name "' + newName + '" is not valid. It must not include "-" and a number.');
                             continue;


### PR DESCRIPTION
I bind a promise from Angular $resource directly to $scope.paths. Controls fails to draw the paths because of internal properties of promise object. This fix is trying to filter them.
