### PR TITLE
Update leafletMapDefaults.js

### DIFF
--- a/src/services/leafletMapDefaults.js
+++ b/src/services/leafletMapDefaults.js
@@ -18,7 +18,7 @@ angular.module("leaflet-directive").factory('leafletMapDefaults', function ($q, 
                 }
             },
             crs: L.CRS.EPSG3857,
-            tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            tileLayer: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             tileLayerOptions: {
                 attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             },


### PR DESCRIPTION
preserves the protocol that was used to load the page (https vs http)
