### PR TITLE
Fixed setting geoJSON on multiple maps in DOM

### DIFF
--- a/src/directives/geojson.js
+++ b/src/directives/geojson.js
@@ -60,7 +60,7 @@ angular.module("leaflet-directive").directive('geojson', function ($log, $rootSc
                         }
 
                         leafletGeoJSON = L.geoJson(geojson.data, geojson.options);
-                        leafletData.setGeoJSON(leafletGeoJSON);
+                        leafletData.setGeoJSON(leafletGeoJSON, attrs.id);
                         leafletGeoJSON.addTo(map);
                     }
                 });


### PR DESCRIPTION
Ran into the issue when navigating between 2 pages, both with a leaflet-map on it containing different data. Initial load went good, second map didn't display the GeoJSON data.
