### PR TITLE
Adding geojson callback to be able to do some post processing

### DIFF
--- a/src/directives/geojson.js
+++ b/src/directives/geojson.js
@@ -66,6 +66,10 @@ angular.module("leaflet-directive").directive('geojson', function ($log, $rootSc
                     leafletGeoJSON = L.geoJson(geojson.data, geojson.options);
                     leafletData.setGeoJSON(leafletGeoJSON);
                     leafletGeoJSON.addTo(map);
+
+                    if (geojson.postLoadCallback) {
+                        geojson.postLoadCallback(map, leafletGeoJSON);
+                    }
                 });
             });
         }


### PR DESCRIPTION
Hi !

I have discovered this great project to integrate leaflet in my angular project, and I have some question about geojson part.
I want to fit map bounds according to geojson data, and I don't know how to do it properly.
If you look at my PR, an ugly callback has been added to be able to define, on geojson options, a `postLoadCallback` : 

```
geojson: {
    data: ...,
    filter: ...,
    postLoadCallback: function(map, feature) {
          // With this call, map will always covert geojson data area
          map.fitBounds(feature.getBounds());
    }
```

Does somebody know how to do it properly with angular/leaflet directive philosophy ?
