### PR TITLE
Updating icon init to obtain custom icon without shadow

### DIFF
--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -48,7 +48,7 @@ angular.module("leaflet-directive").factory('leafletMarkersHelpers', function ($
             iconData.shadowUrl = base64shadow;
         }
 
-        return new L.Icon.Default(iconData);
+        return new L.Icon(iconData);
     };
 
     var _deleteMarker = function(marker, map, layers) {


### PR DESCRIPTION
Context: I wanted to use a custom icon without shadow.

If user specifies iconUrl, I think that it's a better idea to use Icon than DefaultIcon.
Indeed, if shadowUrl is not specified, leaflet will try to load default shadow image, as we are in "DefaultIcon" mode.
