### PR TITLE
Made angular-leaflet-directive compatible with Browserify and Webpack by...

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
   },
   "scripts": {
     "test": "grunt travis --verbose"
-  }
+  },
+  "main": "dist/angular-leaflet-directive"
 }


### PR DESCRIPTION
Made angular-leaflet-directive compatible with Browserify and Webpack by adding a "main" parameter to package.json
