### PR TITLE
add support for ExtraMarkers

### DIFF
--- a/dist/angular-leaflet-directive.js
+++ b/dist/angular-leaflet-directive.js
@@ -2424,7 +2424,7 @@
     'leafletHelpers',
     '$log',
     function ($rootScope, leafletHelpers, $log) {
-      var isDefined = leafletHelpers.isDefined, MarkerClusterPlugin = leafletHelpers.MarkerClusterPlugin, AwesomeMarkersPlugin = leafletHelpers.AwesomeMarkersPlugin, MakiMarkersPlugin = leafletHelpers.MakiMarkersPlugin, safeApply = leafletHelpers.safeApply, Helpers = leafletHelpers, isString = leafletHelpers.isString, isNumber = leafletHelpers.isNumber, isObject = leafletHelpers.isObject, groups = {};
+      var isDefined = leafletHelpers.isDefined, MarkerClusterPlugin = leafletHelpers.MarkerClusterPlugin, AwesomeMarkersPlugin = leafletHelpers.AwesomeMarkersPlugin, MakiMarkersPlugin = leafletHelpers.MakiMarkersPlugin, ExtraMarkersPlugin = leafletHelpers.ExtraMarkersPlugin, safeApply = leafletHelpers.safeApply, Helpers = leafletHelpers, isString = leafletHelpers.isString, isNumber = leafletHelpers.isNumber, isObject = leafletHelpers.isObject, groups = {};
       var createLeafletIcon = function (iconData) {
         if (isDefined(iconData) && isDefined(iconData.type) && iconData.type === 'awesomeMarker') {
           if (!AwesomeMarkersPlugin.isLoaded()) {
@@ -2437,6 +2437,12 @@
             $log.error('[AngularJS - Leaflet] The MakiMarkers Plugin is not loaded.');
           }
           return new L.MakiMarkers.icon(iconData);
+        }
+        if (isDefined(iconData) && isDefined(iconData.type) && iconData.type === 'ExtraMarker') {
+          if (!ExtraMarkersPlugin.isLoaded()) {
+            $log.error('[AngularJS - Leaflet] The ExtraMarkers Plugin is not loaded.');
+          }
+          return new L.ExtraMarkers.icon(iconData);
         }
         if (isDefined(iconData) && isDefined(iconData.type) && iconData.type === 'div') {
           return new L.divIcon(iconData);
@@ -2888,6 +2894,32 @@
           is: function (icon) {
             if (this.isLoaded()) {
               return icon instanceof L.MakiMarkers.Icon;
+            } else {
+              return false;
+            }
+          },
+          equal: function (iconA, iconB) {
+            if (!this.isLoaded()) {
+              return false;
+            }
+            if (this.is(iconA)) {
+              return angular.equals(iconA, iconB);
+            } else {
+              return false;
+            }
+          }
+        },
+        ExtraMarkersPlugin: {
+          isLoaded: function () {
+            if (angular.isDefined(L.ExtraMarkers) && angular.isDefined(L.ExtraMarkers.Icon)) {
+              return true;
+            } else {
+              return false;
+            }
+          },
+          is: function (icon) {
+            if (this.isLoaded()) {
+              return icon instanceof L.ExtraMarkers.Icon;
             } else {
               return false;
             }


### PR DESCRIPTION
Title pretty much says it all adds support for Extra Markers plugin which can then be used like other icons

yellowIcon: {
                    type: 'ExtraMarker',
                    shape: 'circle',
                    icon: 'fa-cog',
                    prefix: 'fa',
                    markerColor: 'yellow'
                },
