### PR TITLE
Issue #425 : Add custom layer

### DIFF
--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -166,7 +166,12 @@ angular.module("leaflet-directive").factory('leafletLayerHelpers', function ($ro
         // and pass it on "createLayer" result for next processes
         custom: {
             createLayer: function (params) {
-                return angular.copy(params.layer);
+                if (params.layer instanceof L.Class) {
+                    return angular.copy(params.layer);
+                }
+                else {
+                    $log.error('[AngularJS - Leaflet] A custom layer must be a leaflet Class');
+                }
             }
         }
     };


### PR DESCRIPTION
Adding a new "custom" type to allow user to create a custom Layer and use it in angular leaflet directive.
To use it : 

```
var customLayer = L.MyCustomLayer(withParams);
var leaflet_parameters = {
    center: {
        lat: ...
        lng: ...
        zoom: ...
    },
    layers: {
        baselayers: {
             layer1: {
                  name: 'myLayer',
                  type: 'custom',
                  layer: customLayer
             }
        }
     }, ...
};
```
