### PR TITLE
Add map.remove on scope $destroy

### DIFF
--- a/src/directives/leaflet.js
+++ b/src/directives/leaflet.js
@@ -99,6 +99,9 @@ angular.module("leaflet-directive", []).directive('leaflet', function ($q, leafl
             });
 
             scope.$on('$destroy', function () {
+                leafletData.getMap().then(function(map) {
+                    map.remove();
+                });
                 leafletData.unresolveMap(attrs.id);
             });
         }


### PR DESCRIPTION
Currently on scope $destroy we only unbind the map variable. I think it would be good to call the map.remove() function to let it destroy all attached handlers and avoid having dead event listeners running.
