### PR TITLE
fix for $watch on paths; closes issue #453

### DIFF
--- a/src/directives/paths.js
+++ b/src/directives/paths.js
@@ -123,9 +123,9 @@ angular.module("leaflet-directive").directive('paths', function ($log, $q, leafl
                             }
                         }
 
-                    });
+                    }, true);
 
-                }, true);
+                });
             });
         }
     };


### PR DESCRIPTION
fix for $watch on paths broken in https://github.com/tombatossals/angular-leaflet-directive/commit/4eef2c9eaea1406c42b367265795539e20b12c42; closes issue #453.
The problem was probably a copy-paste bug - `true` intended to be the third parameter of `$watch` was passed to the newly-created promise chain instead (as the useless second parameter to `then`).
