### PR TITLE
Fix errors launching protractor from Grunt on Windows.

### DIFF
--- a/grunt/shell.js
+++ b/grunt/shell.js
@@ -6,14 +6,14 @@ module.exports = function (grunt, options) {
             stdout: true
         },
         selenium: {
-            command: 'node_modules/protractor/bin/webdriver-manager start',
+            command: 'node node_modules/protractor/bin/webdriver-manager start',
             options: {
                 stdout: false,
                 async: true
             }
         },
         protractor_update: {
-            command: 'node_modules/protractor/bin/webdriver-manager update'
+            command: 'node node_modules/protractor/bin/webdriver-manager update'
         },
         npm_install: {
             command: 'npm install'


### PR DESCRIPTION
This resolves the following issue with running grunt tests on Windows:

grunt test
...
Running "shell:protractor_update" (shell) task

> > 'node_modules\protractor\bin\webdriver-manager' is not recognized as an internal or external command,
> > operable program or batch file.
> > Warning: Done, with errors. Use --force to continue.

Aborted due to warnings.
