### PR TITLE
Came up with a way to handle invalidateSize

### DIFF
--- a/src/directives/leaflet.js
+++ b/src/directives/leaflet.js
@@ -106,6 +106,13 @@ angular.module("leaflet-directive", []).directive('leaflet', function ($q, leafl
                 map.remove();
                 leafletData.unresolveMap(attrs.id);
             });
+
+            //Handle request to invalidate the map size 
+	        //Up scope using $scope.$emit('invalidateSize') 
+	        //Down scope using $scope.$broadcast('invalidateSize')
+            scope.$on('invalidateSize', function() {
+                map.invalidateSize();
+            });
         }
     };
 });


### PR DESCRIPTION
Handle request to invalidate the map size
Up scope using $scope.$emit('invalidateSize')
Down scope using $scope.$broadcast('invalidateSize')
