### PR TITLE
Fit bounds if no center attribute.

### DIFF
--- a/src/directives/maxbounds.js
+++ b/src/directives/maxbounds.js
@@ -23,7 +23,9 @@ angular.module("leaflet-directive").directive('maxbounds', function ($log, leafl
                     ];
 
                     map.setMaxBounds(bounds);
-                    map.fitBounds(bounds);
+                    if (!attrs.center) {
+                            map.fitBounds(bounds);
+                        }
                 });
             });
         }


### PR DESCRIPTION
If maxbounds is set, center was ignored. Change to check for center before map fit bounds. #488 
