### PR TITLE
modify watch expression to allow numeric marker name in angular 1.3

### DIFF
--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -158,7 +158,7 @@ angular.module("leaflet-directive").factory('leafletMarkersHelpers', function ($
         },
 
         addMarkerWatcher: function(marker, name, leafletScope, layers, map) {
-            var clearWatch = leafletScope.$watch("markers."+name, function(markerData, oldMarkerData) {
+            var clearWatch = leafletScope.$watch("markers[\""+name+"\"]", function(markerData, oldMarkerData) {
                 if (!isDefined(markerData)) {
                     _deleteMarker(marker, map, layers);
                     clearWatch();


### PR DESCRIPTION
Parsing of expressions has changed in angular 1.3 (see reports https://github.com/angular/angular.js/issues/9131) and change https://github.com/angular/angular.js/commit/c54228fbe9d42d8a3a159bf84dd1d2e99b259ece

This breaks when angular-leaflet wants to register a marker $watch with a dot and no names are used to name the markers (the marker iteration is made on an array and produces watch expressions like marker.0, marker.1, etc)

When doing a simple $scope.markers.push({lat:lat, lng:lng, message:"My added marker"}) on the map, angular throws.

The error is: "SyntaxError: Unexpected number" when angular tries to parse "markers.0" in getterFn.

This change replaces dot notation with bracket notation which is also allowable as watch expression (https://docs.angularjs.org/guide/expression)
