### PR TITLE
Bump version to 0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <a name="0.7.8"></a>
-### 0.7.8 (2014-08-27)
+### 0.7.9 (2014-10-28)
 
+#### Features
+
+19 pull requests were merged since the previous version: https://github.com/tombatossals/angular-leaflet-directive/pulls?q=is%3Apr+merged%3A2014-08-27..2014-10-28
+
+### 0.7.8 (2014-08-27)
 
 #### Features
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "https://github.com/tombatossals/angular-leaflet-directive/graphs/contributors",
   "name": "angular-leaflet-directive",
   "description": "angular-leaflet-directive - An AngularJS directive to easily interact with Leaflet maps",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "homepage": "http://tombatossals.github.io/angular-leaflet-directive/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Please add release tag. 

For me, this is primarily so bower will recognise and use the updated version. Thanks.
