### PR TITLE
adding check in layers to refresh heatmap data

### DIFF
--- a/src/directives/layers.js
+++ b/src/directives/layers.js
@@ -155,6 +155,12 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                         } else if (newOverlayLayers[newName].visible === false && map.hasLayer(leafletLayers.overlays[newName])) {
                             map.removeLayer(leafletLayers.overlays[newName]);
                         }
+
+                        //refresh heatmap data if present
+                        if (newOverlayLayers[newName].visible && map._loaded && newOverlayLayers[newName].data && newOverlayLayers[newName].type === "heatmap") {
+                            leafletLayers.overlays[newName].setData(newOverlayLayers[newName].data);
+                            leafletLayers.overlays[newName].update();
+                        }
                     }
 
                     // Only add the layers switch selector control if we have more than one baselayer + overlay


### PR DESCRIPTION
In reference to issue 353 [https://github.com/tombatossals/angular-leaflet-directive/issues/353], @tombatossals you had mentioned heatmap data was static. Well, I noticed layers was already being watched, so I added a check to see if the layer is a heatmap type layer, and if so, call setData and update() on it. Now your heatmap can be as dynamic as your data changes and can still have multiple heatmap layers.
