### PR TITLE
fixed the controls directive to correctly use its options

### DIFF
--- a/examples/control-draw-example.html
+++ b/examples/control-draw-example.html
@@ -21,7 +21,7 @@
                 }
            });
            leafletData.getMap().then(function(map) {
-              var drawnItems = $scope.controls.draw.edit.featureGroup;
+              var drawnItems = $scope.controls.edit.featureGroup;
               map.on('draw:created', function (e) {
                 var layer = e.layer;
                 drawnItems.addLayer(layer);

--- a/src/directives/controls.js
+++ b/src/directives/controls.js
@@ -16,17 +16,13 @@ angular.module("leaflet-directive").directive('controls', function ($log, leafle
 
             controller.getMap().then(function(map) {
                 if (isDefined(L.Control.Draw) && isDefined(controls.draw)) {
-                    var drawnItems = new L.FeatureGroup();
-                    var options = {
-                        edit: {
-                            featureGroup: drawnItems
-                        }
-                    };
-                    angular.extend(options, controls.draw);
-                    controls.draw = options;
-                    map.addLayer(options.edit.featureGroup);
 
-                    var drawControl = new L.Control.Draw(options);
+                    if (!isDefined(controls.edit)) {
+                        controls.edit = { featureGroup: new L.FeatureGroup() };
+                        map.addLayer(controls.edit.featureGroup);
+                    }
+
+                    var drawControl = new L.Control.Draw(controls);
                     map.addControl(drawControl);
                 }
 


### PR DESCRIPTION
Issue #349 was closed stating that it was solved, but is was solved by doing: 

```
angular.extend(options, controls.draw);
```

https://github.com/tombatossals/angular-leaflet-directive/blob/master/src/directives/controls.js#L25
But now you have to do this in your controller to make it work: 

```
 $scope.controls= {
        draw: {
            draw: {
                polygon : false,
            }
        }
    };

<leaflet controls="controls" height="480px" width="640px"></leaflet>
```

This is because the options object is being flattened out and passed to leaflet.draw which  expects an object with a draw property on it (which is not on it, because it is flattened out).

With the current fix, the edit and position options will also be passed to leaflet.draw. See (https://github.com/Leaflet/Leaflet.draw/blob/master/src/Control.Draw.js#L3-L7) for the API

I also think that Issue: #523 is related to this problem.
