### PR TITLE
Fix the failure to run the e2e tests

### DIFF
--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -15,7 +15,7 @@ exports.config = {
   // chromeDriver)
 
   // The location of the selenium standalone server .jar file.
-  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.42.2.jar',
+  seleniumServerJar: '../node_modules/protractor/selenium/selenium-server-standalone-2.44.0.jar',
   // The port to start the selenium server on, or null if the server should
   // find its own unused port.
   seleniumPort: null,


### PR DESCRIPTION
I ended up with the following error while trying to run the `e2e` tests (The `unit` ones however run all fine):

```
~/dev/workspace/angular-leaflet-directive>grunt test-e2e
Running "shell:protractor_update" (shell) task
selenium standalone is up to date.
chromedriver is up to date.

Running "connect:testserver" (connect) task
Started connect web server on http://0.0.0.0:9999

Running "protractor:run" (protractor) task

/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:126
                    throw e;
                          ^
Error: there's no selenium server jar at the specified location. Do you have the correct version?
    at LocalDriverProvider.setupEnv (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/lib/driverProviders/local.js:61:11)
    at Runner.run (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/lib/runner.js:215:31)
    at /Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/lib/launcher.js:163:14
    at _fulfilled (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:797:54)
    at self.promiseDispatch.done (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:826:30)
    at Promise.promise.promiseDispatch (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:759:13)
    at /Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:820:14
    at flush (/Users/bvahdat/dev/workspace/angular-leaflet-directive/node_modules/protractor/node_modules/q/q.js:108:17)
    at process._tickCallback (node.js:419:13)
    at Function.Module.runMain (module.js:499:11)
>> 
Fatal error: protractor exited with code: 8
```
