### PR TITLE
Allow you to change baselayers on demand

### DIFF
--- a/src/directives/layercontrol.js
+++ b/src/directives/layercontrol.js
@@ -140,12 +140,6 @@ angular.module("leaflet-directive").directive('layercontrol', function ($log, le
 
         scope.layers = layers;
         controller.getMap().then(function(map) {
-            // Do we have a baselayers property?
-            if (!isDefined(layers) || !isDefined(layers.baselayers) || Object.keys(layers.baselayers).length === 0) {
-                // No baselayers property
-                $log.error('[AngularJS - Leaflet] At least one baselayer has to be defined');
-                return;
-            }
 
             leafletScope.$watch('layers.baselayers', function(newBaseLayers) {
                 leafletData.getLayers().then(function(leafletLayers) {

--- a/src/directives/layers.js
+++ b/src/directives/layers.js
@@ -20,12 +20,6 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                 isLayersControlVisible = false;
 
             controller.getMap().then(function(map) {
-                // Do we have a baselayers property?
-                if (!isDefined(layers) || !isDefined(layers.baselayers) || Object.keys(layers.baselayers).length === 0) {
-                    // No baselayers property
-                    $log.error('[AngularJS - Leaflet] At least one baselayer has to be defined');
-                    return;
-                }
 
                 // We have baselayers to add to the map
                 scope._leafletLayers.resolve(leafletLayers);
@@ -98,11 +92,13 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                                     map.addLayer(leafletLayers.baselayers[newName]);
                                 }
                             }
+                        } else {
+                            if (newBaseLayers[newName].top === true && !map.hasLayer(leafletLayers.baselayers[newName])) {
+                                map.addLayer(leafletLayers.baselayers[newName]);
+                            } else if (newBaseLayers[newName].top === false && map.hasLayer(leafletLayers.baselayers[newName])) {
+                                map.removeLayer(leafletLayers.baselayers[newName]);
+                            }
                         }
-                    }
-                    if (Object.keys(leafletLayers.baselayers).length === 0) {
-                        $log.error('[AngularJS - Leaflet] At least one baselayer has to be defined');
-                        return;
                     }
 
                     //we have layers, so we need to make, at least, one active
@@ -115,7 +111,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                         }
                     }
                     // If there is no active layer make one active
-                    if (!found) {
+                    if (!found && Object.keys(layers.baselayers).length > 0) {
                         map.addLayer(leafletLayers.baselayers[Object.keys(layers.baselayers)[0]]);
                     }
 

--- a/test/unit/layersDirectiveSpec.js
+++ b/test/unit/layersDirectiveSpec.js
@@ -28,25 +28,26 @@ describe('Directive: leaflet', function() {
         var element = angular.element('<leaflet></leaflet>');
         element = $compile(element)(scope);
         scope.$digest();
-        leafletData.getLayers().then(function() {
-            expect(layers).toBe(undefined);
+        leafletData.getLayers().then(function(layers) {
+            expect(layers).toBe({});
         });
     });
 
-    it('should not create layers if they are miss-configured', function() {
+    it('miss-configured layers persist', function() {
+        var nolayers = {
+            baselayers: {},
+            overlays: {}
+        };
         angular.extend(scope, {
-            layers: {
-                baselayers: {},
-                overlays: {}
-            }
+            layers: nolayers
         });
 
         // If we not provide layers the system will use the default
         var element = angular.element('<leaflet layers="layers"></leaflet>');
         element = $compile(element)(scope);
         scope.$digest();
-        leafletData.getLayers().then(function() {
-            expect(layers).toBe(undefined);
+        leafletData.getLayers().then(function(layers) {
+            expect(layers).toEqual(nolayers);
         });
     });
 


### PR DESCRIPTION
There is a case where you retrieve baselayers on demand (via web request).
When this happens, the baselayers are added after the map is initialized.
