### PR TITLE
Option to exclude overlays from layer control

### DIFF
--- a/src/services/leafletControlHelpers.js
+++ b/src/services/leafletControlHelpers.js
@@ -65,7 +65,9 @@ angular.module("leaflet-directive").factory('leafletControlHelpers', function ($
                     }
                 }
                 for (i in overlays) {
-                    if (isDefined(leafletLayers.overlays[i])) {
+                	var hideOverlayOnSelector = isDefined(overlays[i].layerOptions) &&
+                            overlays[i].layerOptions.showOnSelector === false;
+                    if (!hideOverlayOnSelector && isDefined(leafletLayers.overlays[i])) {
                         _layersControl.addOverlay(leafletLayers.overlays[i], overlays[i].name);
                     }
                 }


### PR DESCRIPTION
The option to exclude baselayers from the layer control is great; giving that functionality to overlays should be useful.
Just use the overlay's layerOptions like that: 

```javascript
layerOptions:{
    showOnSelector: false
}
```