### PR TITLE
required center attribute was missing

### DIFF
--- a/doc/bounds-attribute.md
+++ b/doc/bounds-attribute.md
@@ -4,7 +4,7 @@
 This sub-directive needs the **leaflet** main directive, so it is normaly used as an attribute of the *leaflet* tag, like this:
 
 ```
-<leaflet bounds="bounds"></leaflet>
+<leaflet bounds="bounds" center="center"></leaflet>
 ```
 
 It will map an object _bounds_ of our controller scope with the corresponding object on our leaflet directive isolated scope. It's a bidirectional relationship, so a change in this object on the controller scope object will affect the map bounds, or an interaction on the map which changes the map position will update our _bounds_ values. Let's define the bounds model with an example:


### PR DESCRIPTION
When attempting to use this I noticed that the centre attribute was missing. It took me over an hour to work out what the problem was as I was following the documentation. I've fixed it here so that other people won't make the same mistake.