### PR TITLE
Better management of layer control addition/removal of items

### DIFF
--- a/examples/0212-layers-hide-overlays-on-selector-example.html
+++ b/examples/0212-layers-hide-overlays-on-selector-example.html
@@ -14,6 +14,9 @@
                     lng: -100,
                     zoom: 4
                 },
+                defaults: {
+                    scrollWheelZoom: false
+                },
                 layers: {
                     baselayers: {
                         xyz: {
@@ -21,6 +24,7 @@
                             url: 'http://a.tiles.mapbox.com/v3/examples.map-i86nkdio/{z}/{x}/{y}.png',
                             type: 'xyz',
                             layerOptions: {
+                                showOnSelector: true,
                                 apikey: 'pk.eyJ1IjoiYnVmYW51dm9scyIsImEiOiJLSURpX0pnIn0.2_9NrLz1U9bpwMQBhVk97Q',
                                 mapid: 'bufanuvols.ll5em372'
                             }
@@ -33,7 +37,7 @@
                             visible: true,
                             url: 'http://suite.opengeo.org/geoserver/usa/wms',
                             layerParams: {
-                                showOnSelector: false,
+                                showOnSelector: true,
                                 layers: 'usa:states',
                                 format: 'image/png',
                                 transparent: true
@@ -46,8 +50,10 @@
     </script>
 </head>
 <body ng-controller="LayersHideOverlaysOnSelectorController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet center="center" defaults="defaults" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Overlay not shown in selector</h1>
+    <button ng-click="layers.overlays.wms.layerParams.showOnSelector = !layers.overlays.wms.layerParams.showOnSelector">Toggle Overlay visibility on Selector</button>
+    <button ng-click="layers.baselayers.xyz.layerOptions.showOnSelector = !layers.baselayers.xyz.layerOptions.showOnSelector">Toggle BaseLayer visibility on Selector</button>
     <p>You can hide the enable/disable functionality of the overlay in the selector, using this attribute in the layerOptions object:</p>
     <pre>layerOptions: {
     showOnSelector: false

--- a/src/services/leafletControlHelpers.js
+++ b/src/services/leafletControlHelpers.js
@@ -1,6 +1,6 @@
 angular.module("leaflet-directive").factory('leafletControlHelpers', function ($rootScope, $log, leafletHelpers, leafletMapDefaults) {
-    var isObject = leafletHelpers.isObject,
-        isDefined = leafletHelpers.isDefined;
+    var isDefined = leafletHelpers.isDefined;
+    var isObject = leafletHelpers.isObject;
     var _controls = {};
 
     var _controlLayersMustBeVisible = function(baselayers, overlays, mapId) {
@@ -9,21 +9,35 @@ angular.module("leaflet-directive").factory('leafletControlHelpers', function ($
             return false;
         }
 
-        var numberOfLayers = 0;
+        var atLeastOneControlItemMustBeShown = false;
+
         if (isObject(baselayers)) {
-            numberOfLayers += Object.keys(baselayers).length;
+            Object.keys(baselayers).forEach(function(key) {
+                var layer = baselayers[key];
+                if (!isDefined(layer.layerOptions) || layer.layerOptions.showOnSelector !== false) {
+                    atLeastOneControlItemMustBeShown = true;
+                }
+            });
         }
+
         if (isObject(overlays)) {
-            numberOfLayers += Object.keys(overlays).length;
+            Object.keys(overlays).forEach(function(key) {
+                var layer = overlays[key];
+                if (!isDefined(layer.layerParams) || layer.layerParams.showOnSelector !== false) {
+                    atLeastOneControlItemMustBeShown = true;
+                }
+            });
         }
-        return numberOfLayers > 1;
+
+        return atLeastOneControlItemMustBeShown;
     };
 
     var _createLayersControl = function(mapId) {
         var defaults = leafletMapDefaults.getDefaults(mapId);
         var controlOptions = {
             collapsed: defaults.controls.layers.collapsed,
-            position: defaults.controls.layers.position
+            position: defaults.controls.layers.position,
+            autoZIndex: false
         };
 
         angular.extend(controlOptions, defaults.controls.layers.options);
@@ -74,6 +88,7 @@ angular.module("leaflet-directive").factory('leafletControlHelpers', function ($
                         _layersControl.addOverlay(leafletLayers.overlays[i], overlays[i].name);
                     }
                 }
+
                 map.addControl(_layersControl);
             }
             return mustBeLoaded;


### PR DESCRIPTION
This PR adds a better management of the layer control, now it will show/hide the layers control items correctly based on the "layerOptions", "showOnSelector" property.

This example has been improved to show this new functionality too:

http://tombatossals.github.io/angular-leaflet-directive/examples/0212-layers-hide-overlays-on-selector-example.html