### PR TITLE
Control.fullscreen

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
     "proj4leaflet": "*",
     "Leaflet.MakiMarkers": "*",
     "Leaflet.ExtraMarkers": "git://github.com/coryasilva/Leaflet.ExtraMarkers#master",
+    "Leaflet.fullscreen": "git@github.com:Leaflet/Leaflet.fullscreen.git#gh-pages",
     "Leaflet.PolylineDecorator": "bbecquet/Leaflet.PolylineDecorator",
     "ionrangeslider": "~1.9.3"
   },

--- a/examples/0403-controls-fullscreen-example.html
+++ b/examples/0403-controls-fullscreen-example.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html ng-app="demoapp">
+  <head>
+    <script src="../bower_components/angular/angular.min.js"></script>
+    <script src="../bower_components/leaflet/dist/leaflet.js"></script>
+    <script src="../bower_components/Leaflet.fullscreen/dist/Leaflet.fullscreen.min.js"></script>
+    <script src="../dist/angular-leaflet-directive.min.js"></script>
+    <link rel="stylesheet" href="../bower_components/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="../bower_components/Leaflet.fullscreen/dist/leaflet.fullscreen.css" />
+
+    <script>
+        var app = angular.module("demoapp", ["leaflet-directive"]);
+        app.controller("ControlsFullscreenController", [ "$scope", function($scope) {
+            angular.extend($scope, {
+                london: {
+                    lat: 37.8,
+                    lng: -96,
+                    zoom: 5
+                },
+                tiles: {
+                    name: 'Mapbox Comic',
+                    url: 'http://api.tiles.mapbox.com/v4/{mapid}/{z}/{x}/{y}.png?access_token={apikey}',
+                    type: 'xyz',
+                    options: {
+                        apikey: 'pk.eyJ1IjoiYnVmYW51dm9scyIsImEiOiJLSURpX0pnIn0.2_9NrLz1U9bpwMQBhVk97Q',
+                        mapid: 'bufanuvols.lpa06kfg'
+                    }
+                },
+                controls: {
+                    fullscreen: {
+                        position: 'topleft'
+                    }
+                }
+           });
+       }]);
+    </script>
+  </head>
+  <body ng-controller="ControlsFullscreenController">
+    <leaflet center="london" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
+    <h1>Fullscreen control example</h1>
+    <p>Fullscreen control with the <a href="https://github.com/Leaflet/Leaflet.fullscreen">Leaflet fullscreen</a> plugin.</p>
+  </body>
+</html>

--- a/examples/js/controllers.js
+++ b/examples/js/controllers.js
@@ -796,6 +796,69 @@ var app = angular.module('webapp');
             });
         });
       } ]);
+    app.controller("GeoJSONNestedController", [ '$scope', '$http', 'leafletData', function($scope, $http, leafletData) {
+        leafletData.getGeoJSON().then(function(lObjs){
+            window.leafletDataGeoJSON = lObjs;
+        });
+        angular.extend($scope, {
+            japan: {
+                lat: 27.26,
+                lng: 78.86,
+                zoom: 2
+            },
+            defaults: {
+                scrollWheelZoom: false
+            },
+            geojson:{}
+        });
+        $scope.centerJSON = function(name) {
+            leafletData.getMap().then(function(map) {
+                window.leafletMap = map;
+                var latlngs = [];
+                for (var i in $scope.geojson[name].data.features[0].geometry.coordinates) {
+                    var coord = $scope.geojson[name].data.features[0].geometry.coordinates[i];
+                    for (var j in coord) {
+                        var points = coord[j];
+                        for (var k in points) {
+                            latlngs.push(L.GeoJSON.coordsToLatLng(points[k]));
+                        }
+                    }
+                }
+                map.fitBounds(latlngs);
+            });
+        };
+        // Get the countries geojson data from a JSON
+        $http.get("json/JPN.geo.json").success(function(data, status) {
+            angular.extend($scope.geojson, {
+                japan: {
+                    data: data,
+                    style: {
+                        fillColor: "green",
+                        weight: 2,
+                        opacity: 1,
+                        color: 'white',
+                        dashArray: '3',
+                        fillOpacity: 0.7
+                    }
+                }
+            });
+        });
+        $http.get("json/USA.geo.json").success(function(data, status) {
+            angular.extend($scope.geojson, {
+                usa:{
+                    data: data,
+                    style: {
+                        fillColor: "blue",
+                        weight: 2,
+                        opacity: 1,
+                        color: 'white',
+                        dashArray: '3',
+                        fillOpacity: 0.7
+                    }
+                }
+            });
+        });
+    } ]);
     app.controller("GeoJSONNonNestedController", [ '$scope', '$http', 'leafletData', function($scope, $http, leafletData) {
         var getColor = function(id){
             return id == 'USA'? 'blue' : 'green';

--- a/examples/js/controllers/GeoJSONNestedController.js
+++ b/examples/js/controllers/GeoJSONNestedController.js
@@ -1,17 +1,7 @@
-<!DOCTYPE html>
-<html ng-app="demoapp">
-<head>
-    <script src="../bower_components/angular/angular.min.js"></script>
-    <script src="../bower_components/leaflet/dist/leaflet.js"></script>
-    <script src="../dist/angular-leaflet-directive_dev_mapped.js"></script>
-    <link rel="stylesheet" href="../bower_components/leaflet/dist/leaflet.css" />
-    <script>
-    var app = angular.module("demoapp", ["leaflet-directive"]);
     app.controller("GeoJSONNestedController", [ '$scope', '$http', 'leafletData', function($scope, $http, leafletData) {
         leafletData.getGeoJSON().then(function(lObjs){
             window.leafletDataGeoJSON = lObjs;
         });
-
         angular.extend($scope, {
             japan: {
                 lat: 27.26,
@@ -23,7 +13,6 @@
             },
             geojson:{}
         });
-
         $scope.centerJSON = function(name) {
             leafletData.getMap().then(function(map) {
                 window.leafletMap = map;
@@ -40,7 +29,6 @@
                 map.fitBounds(latlngs);
             });
         };
-
         // Get the countries geojson data from a JSON
         $http.get("json/JPN.geo.json").success(function(data, status) {
             angular.extend($scope.geojson, {
@@ -73,12 +61,3 @@
             });
         });
     } ]);
-    </script>
-</head>
-<body ng-controller="GeoJSONNestedController">
-    <leaflet center="japan" geojson="geojson" geojson-nested="true" width="100%" height="480px"></leaflet>
-    <h1>GeoJSON nested example</h1>
-    <input type="button" value="center usa" ng-click="centerJSON('usa')" />
-    <input type="button" value="center jpn" ng-click="centerJSON('japan')" />
-</body>
-</html>

--- a/examples/json/examples.json
+++ b/examples/json/examples.json
@@ -201,7 +201,7 @@
             "title": "GeoJSON non nested example"
         },
         {
-            "date": "2015-04-18T19:40:30.921Z",
+            "date": "2015-04-19T08:13:07.879Z",
             "section": "basic",
             "onlyStandAlone": false,
             "id": "/basic/geojson-nested-example",
@@ -529,7 +529,7 @@
             "title": "Marker clustering example without layers"
         },
         {
-            "date": "2015-04-18T20:49:36.382Z",
+            "date": "2015-04-19T09:02:03.579Z",
             "section": "markers",
             "onlyStandAlone": false,
             "id": "/markers/modal-markercluster-example",

--- a/src/directives/controls.js
+++ b/src/directives/controls.js
@@ -31,6 +31,15 @@ angular.module("leaflet-directive").directive('controls', function ($log, leafle
                     map.addControl(scaleControl);
                 }
 
+                if (isDefined(controls.fullscreen)) {
+                    if (leafletHelpers.FullScreenControlPlugin.isLoaded()) {
+                        var fullscreenControl = new L.Control.Fullscreen(controls.fullscreen);
+                        map.addControl(fullscreenControl);
+                    } else {
+                        $log.error('[AngularJS - Leaflet] Fullscreen plugin is not loaded.');
+                    }
+                }
+
                 if (isDefined(controls.custom)) {
                     for(var i in controls.custom) {
                         map.addControl(controls.custom[i]);

--- a/src/services/leafletHelpers.js
+++ b/src/services/leafletHelpers.js
@@ -215,13 +215,15 @@ angular.module("leaflet-directive").factory('leafletHelpers', function ($q, $log
             d[id].resolvedDefer = true;
         },
 
+        FullScreenControlPlugin: {
+            isLoaded: function() {
+                return angular.isDefined(L.Control.Fullscreen);
+            }
+        },
+
         AwesomeMarkersPlugin: {
             isLoaded: function() {
-                if (angular.isDefined(L.AwesomeMarkers) && angular.isDefined(L.AwesomeMarkers.Icon)) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return angular.isDefined(L.AwesomeMarkers) && angular.isDefined(L.AwesomeMarkers.Icon);
             },
             is: function(icon) {
                 if (this.isLoaded()) {

--- a/test/e2e/0107-basic-tiles-example.js
+++ b/test/e2e/0107-basic-tiles-example.js
@@ -2,7 +2,6 @@
 
 describe('Loading 0107-basic-tiles-example.html', function() {
 
-    var ptor, driver;
     beforeEach(function() {
         browser.get('0107-basic-tiles-example.html');
         browser.wait(function() {

--- a/test/e2e/0205-layers-googlemaps-example.js
+++ b/test/e2e/0205-layers-googlemaps-example.js
@@ -2,7 +2,6 @@
 
 describe('Loading 0205-layers-googlemaps-example.html', function() {
 
-    var ptor, driver;
     beforeEach(function() {
         browser.get('0205-layers-googlemaps-example.html');
         browser.wait(function() {


### PR DESCRIPTION
Added the Leaflet.fullscreen plugin funcionality inside the directive. You can add a fullscreen control with this code:

```
    // scope
    controls: {
        fullscreen: {
            position: 'topleft'
        }
    }
```

and in the directive declaration:
```
    <leaflet center="center" controls="controls"></leaflet>
```

There's an example of use inside this PR.

Motivated by this issue: https://github.com/tombatossals/angular-leaflet-directive/issues/644