### PR TITLE
Update leafletMarkerEvents.js

### DIFF
--- a/src/services/events/leafletMarkerEvents.js
+++ b/src/services/events/leafletMarkerEvents.js
@@ -47,7 +47,12 @@ angular.module("leaflet-directive")
         'move',
         'remove',
         'popupopen',
-        'popupclose'
+        'popupclose',
+        'touchend',
+        'touchstart',
+        'touchmove',
+        'touchcancel',
+        'touchleave'
         ];
     };
 


### PR DESCRIPTION
This enables us to notice marker events on mobile. got the touch events list from https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#Setting_up_the_event_handlers this should fix #743