### PR TITLE
Update leafletLayerHelpers.js

### DIFF
--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -193,7 +193,10 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                return L.esri.featureLayer(params.url, params.options);
+                
+                params.options.url = params.url;
+                
+                return L.esri.featureLayer(params.options);
             }
         },
         agsTiled: {
@@ -203,7 +206,10 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                return L.esri.tiledMapLayer(params.url, params.options);
+                
+                params.options.url = params.url;
+                
+                return L.esri.tiledMapLayer(params.options);
             }
         },
         agsDynamic: {
@@ -213,7 +219,10 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                return L.esri.dynamicMapLayer(params.url, params.options);
+                
+                params.options.url = params.url;
+                
+                return L.esri.dynamicMapLayer(params.options);
             }
         },
         agsImage: {
@@ -223,7 +232,9 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                return L.esri.imageMapLayer(params.url, params.options);
+                 params.options.url = params.url;
+                
+                return L.esri.imageMapLayer(params.options);
             }
         },
         agsClustered: {


### PR DESCRIPTION
Update for compatibility with ESRI Leaflet 1.0.0. The url should be passed as a property of the 'options' object rather than as a separate argument. 
See 1.0 upgrade changes to esri leaflet here: https://github.com/Esri/esri-leaflet/commit/9f81ca39d770905ea2ac2f1e84e276684e33bb5d#diff-a7be8ad7c53337df7dc83d076f320957