### PR TITLE
Protect against iterating over custom array

### DIFF
--- a/src/services/leafletIterators.js
+++ b/src/services/leafletIterators.js
@@ -143,7 +143,9 @@ angular.module('leaflet-directive').service('leafletIterators', function ($log, 
     }
     if(!_hasErrors(collection, externalCb)){
       for(var key in collection){
-        internalCb(collection[key], key);
+          if (collection.hasOwnProperty(key)) {
+              internalCb(collection[key], key);
+          }
       }
     }
   };


### PR DESCRIPTION
Sometimes some properties/polyfills are attached to the Array prototypes which the iterator module is not protected against.

For example in my case, we have `Array.prototype.findIndex` and `Array.prototype.find` defined in an other library which try to avoid using lodash. It ends up throwing a `TypeError` exception and display some unwanted layers in the control:

![image](https://cloud.githubusercontent.com/assets/208512/9153693/f1e93f8a-3ea3-11e5-9199-b622cbcc9cda.png)

I made a pull request with an approach based on a [hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) check but alternatively getting the keys with [getOwnPropertyNames()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames) could be an option as well.