### PR TITLE
fix(dependencies): utfgrid now specifies main file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,11 +48,6 @@
     "esri-leaflet-heatmap-feature-layer": "~1.0.x",
     "leaflet-search": "~1.5.8"
   },
-  "overrides": {
-    "Leaflet.utfgrid": {
-      "main": "dist/leaflet.utfgrid.js"
-    }
-  },
   "ignore": [
     "**/.*",
     "src",


### PR DESCRIPTION
Since danzel/Leaflet.utfgrid#36, a main file is specified. So the
override is no longer needed.