### PR TITLE
fix(dependencies): remove dependency font-awesome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,7 @@
   ],
   "dependencies": {
     "angular": "1.x",
-    "leaflet": "0.7.x",
-    "font-awesome": "~4.3.x"
+    "leaflet": "0.7.x"
   },
   "devDependencies": {
     "jquery": "*",


### PR DESCRIPTION
This dependency has been added in #418 and is only useful in the context
of a specific plugin.