### PR TITLE
Add support for IIP plugin

### DIFF
--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -100,7 +100,7 @@ angular.module("leaflet-directive").directive('center',
                 }
 
                 leafletScope.$watch("center", function(center) {
-                    if (scope.settingCenterFromLeaflet)
+                    if (leafletScope.settingCenterFromLeaflet)
                         return;
                     //$log.debug("updated center model...");
                     // The center from the URL has priority
@@ -153,11 +153,11 @@ angular.module("leaflet-directive").directive('center',
                     _leafletCenter.resolve();
                     leafletEvents.notifyCenterUrlHashChanged(leafletScope, map, attrs, $location.search());
                     //$log.debug("updated center on map...");
-                    if (isSameCenterOnMap(centerModel, map) || scope.settingCenterFromScope) {
+                    if (isSameCenterOnMap(centerModel, map) || leafletScope.settingCenterFromScope) {
                         //$log.debug("same center in model, no need to update again.");
                         return;
                     }
-                    scope.settingCenterFromLeaflet = true;
+                    leafletScope.settingCenterFromLeaflet = true;
                     safeApply(leafletScope, function(scope) {
                         if (!leafletScope.settingCenterFromScope) {
                             //$log.debug("updating center model...", map.getCenter(), map.getZoom());
@@ -170,7 +170,7 @@ angular.module("leaflet-directive").directive('center',
                         }
                         leafletEvents.notifyCenterChangedToBounds(leafletScope, map);
                         $timeout( function() {
-                            scope.settingCenterFromLeaflet = false;
+                            leafletScope.settingCenterFromLeaflet = false;
                         });
                     });
                 });

--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -100,7 +100,7 @@ angular.module("leaflet-directive").directive('center',
                 }
 
                 leafletScope.$watch("center", function(center) {
-                    if (leafletScope.settingCenterFromLeaflet)
+                    if (scope.settingCenterFromLeaflet)
                         return;
                     //$log.debug("updated center model...");
                     // The center from the URL has priority
@@ -153,11 +153,11 @@ angular.module("leaflet-directive").directive('center',
                     _leafletCenter.resolve();
                     leafletEvents.notifyCenterUrlHashChanged(leafletScope, map, attrs, $location.search());
                     //$log.debug("updated center on map...");
-                    if (isSameCenterOnMap(centerModel, map) || leafletScope.settingCenterFromScope) {
+                    if (isSameCenterOnMap(centerModel, map) || scope.settingCenterFromScope) {
                         //$log.debug("same center in model, no need to update again.");
                         return;
                     }
-                    leafletScope.settingCenterFromLeaflet = true;
+                    scope.settingCenterFromLeaflet = true;
                     safeApply(leafletScope, function(scope) {
                         if (!leafletScope.settingCenterFromScope) {
                             //$log.debug("updating center model...", map.getCenter(), map.getZoom());
@@ -170,7 +170,7 @@ angular.module("leaflet-directive").directive('center',
                         }
                         leafletEvents.notifyCenterChangedToBounds(leafletScope, map);
                         $timeout( function() {
-                            leafletScope.settingCenterFromLeaflet = false;
+                            scope.settingCenterFromLeaflet = false;
                         });
                     });
                 });

--- a/src/directives/layers.js
+++ b/src/directives/layers.js
@@ -42,14 +42,14 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     // Only add the visible layer to the map, layer control manages the addition to the map
                     // of layers in its control
                     if (layers.baselayers[layerName].top === true) {
-                        map.addLayer(leafletLayers.baselayers[layerName]);
+                        leafletLayers.baselayers[layerName].addTo(map);
                         oneVisibleLayer = true;
                     }
                 }
 
                 // If there is no visible layer add first to the map
                 if (!oneVisibleLayer && Object.keys(leafletLayers.baselayers).length > 0) {
-                    map.addLayer(leafletLayers.baselayers[Object.keys(layers.baselayers)[0]]);
+                    leafletLayers.baselayers[Object.keys(layers.baselayers)[0]].addTo(map);
                 }
 
                 // Setup the Overlays
@@ -65,7 +65,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     leafletLayers.overlays[layerName] = newOverlayLayer;
                     // Only add the visible overlays to the map
                     if (layers.overlays[layerName].visible === true) {
-                        map.addLayer(leafletLayers.overlays[layerName]);
+                        leafletLayers.overlays[layerName].addTo(map);
                     }
                 }
 
@@ -97,12 +97,12 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                                 leafletLayers.baselayers[newName] = testBaseLayer;
                                 // Only add the visible layer to the map
                                 if (newBaseLayers[newName].top === true) {
-                                    map.addLayer(leafletLayers.baselayers[newName]);
+                                    leafletLayers.baselayers[newName].addTo(map);
                                 }
                             }
                         } else {
                             if (newBaseLayers[newName].top === true && !map.hasLayer(leafletLayers.baselayers[newName])) {
-                                map.addLayer(leafletLayers.baselayers[newName]);
+                                leafletLayers.baselayers[newName].addTo(map);
                             } else if (newBaseLayers[newName].top === false && map.hasLayer(leafletLayers.baselayers[newName])) {
                                 map.removeLayer(leafletLayers.baselayers[newName]);
                             }
@@ -120,7 +120,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     }
                     // If there is no active layer make one active
                     if (!found && Object.keys(leafletLayers.baselayers).length > 0) {
-                        map.addLayer(leafletLayers.baselayers[Object.keys(leafletLayers.baselayers)[0]]);
+                        leafletLayers.baselayers[Object.keys(leafletLayers.baselayers)[0]].addTo(map);
                     }
 
                     // Only show the layers switch selector control if we have more than one baselayer + overlay
@@ -159,13 +159,13 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                             }
                             leafletLayers.overlays[newName] = testOverlayLayer;
                             if (newOverlayLayers[newName].visible === true) {
-                                map.addLayer(leafletLayers.overlays[newName]);
+                                leafletLayers.overlays[newName].addTo(map);
                             }
                         }
 
                         // check for the .visible property to hide/show overLayers
                         if (newOverlayLayers[newName].visible && !map.hasLayer(leafletLayers.overlays[newName])) {
-                            map.addLayer(leafletLayers.overlays[newName]);
+                            leafletLayers.overlays[newName].addTo(map);
                         } else if (newOverlayLayers[newName].visible === false && map.hasLayer(leafletLayers.overlays[newName])) {
                             map.removeLayer(leafletLayers.overlays[newName]);
                         }

--- a/src/directives/layers.js
+++ b/src/directives/layers.js
@@ -16,6 +16,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                 leafletScope  = controller.getLeafletScope(),
                 layers = leafletScope.layers,
                 createLayer = leafletLayerHelpers.createLayer,
+                safeAddLayer = leafletLayerHelpers.safeAddLayer,
                 updateLayersControl = leafletControlHelpers.updateLayersControl,
                 isLayersControlVisible = false;
 
@@ -42,14 +43,14 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     // Only add the visible layer to the map, layer control manages the addition to the map
                     // of layers in its control
                     if (layers.baselayers[layerName].top === true) {
-                        leafletLayers.baselayers[layerName].addTo(map);
+                        safeAddLayer(map, leafletLayers.baselayers[layerName]);
                         oneVisibleLayer = true;
                     }
                 }
 
                 // If there is no visible layer add first to the map
                 if (!oneVisibleLayer && Object.keys(leafletLayers.baselayers).length > 0) {
-                    leafletLayers.baselayers[Object.keys(layers.baselayers)[0]].addTo(map);
+                    safeAddLayer(map, leafletLayers.baselayers[Object.keys(layers.baselayers)[0]]);
                 }
 
                 // Setup the Overlays
@@ -65,7 +66,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     leafletLayers.overlays[layerName] = newOverlayLayer;
                     // Only add the visible overlays to the map
                     if (layers.overlays[layerName].visible === true) {
-                        leafletLayers.overlays[layerName].addTo(map);
+                        safeAddLayer(map, leafletLayers.overlays[layerName]);
                     }
                 }
 
@@ -97,12 +98,12 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                                 leafletLayers.baselayers[newName] = testBaseLayer;
                                 // Only add the visible layer to the map
                                 if (newBaseLayers[newName].top === true) {
-                                    leafletLayers.baselayers[newName].addTo(map);
+                                    safeAddLayer(map, leafletLayers.baselayers[newName]);
                                 }
                             }
                         } else {
                             if (newBaseLayers[newName].top === true && !map.hasLayer(leafletLayers.baselayers[newName])) {
-                                leafletLayers.baselayers[newName].addTo(map);
+                                safeAddLayer(map, leafletLayers.baselayers[newName]);
                             } else if (newBaseLayers[newName].top === false && map.hasLayer(leafletLayers.baselayers[newName])) {
                                 map.removeLayer(leafletLayers.baselayers[newName]);
                             }
@@ -120,7 +121,7 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                     }
                     // If there is no active layer make one active
                     if (!found && Object.keys(leafletLayers.baselayers).length > 0) {
-                        leafletLayers.baselayers[Object.keys(leafletLayers.baselayers)[0]].addTo(map);
+                        safeAddLayer(map, leafletLayers.baselayers[Object.keys(leafletLayers.baselayers)[0]]);
                     }
 
                     // Only show the layers switch selector control if we have more than one baselayer + overlay
@@ -159,15 +160,15 @@ angular.module("leaflet-directive").directive('layers', function ($log, $q, leaf
                             }
                             leafletLayers.overlays[newName] = testOverlayLayer;
                             if (newOverlayLayers[newName].visible === true) {
-                                leafletLayers.overlays[newName].addTo(map);
+                                safeAddLayer(map, leafletLayers.overlays[newName]);
                             }
-                        }
-
-                        // check for the .visible property to hide/show overLayers
-                        if (newOverlayLayers[newName].visible && !map.hasLayer(leafletLayers.overlays[newName])) {
-                            leafletLayers.overlays[newName].addTo(map);
-                        } else if (newOverlayLayers[newName].visible === false && map.hasLayer(leafletLayers.overlays[newName])) {
-                            map.removeLayer(leafletLayers.overlays[newName]);
+                        } else {
+                            // check for the .visible property to hide/show overLayers
+                            if (newOverlayLayers[newName].visible && !map.hasLayer(leafletLayers.overlays[newName])) {
+                                safeAddLayer(map, leafletLayers.overlays[newName]);
+                            } else if (newOverlayLayers[newName].visible === false && map.hasLayer(leafletLayers.overlays[newName])) {
+                                map.removeLayer(leafletLayers.overlays[newName]);
+                            }
                         }
 
                         //refresh heatmap data if present

--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -210,9 +210,9 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                
+
                 params.options.url = params.url;
-                
+
                 return L.esri.featureLayer(params.options);
             }
         },
@@ -223,9 +223,9 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                
+
                 params.options.url = params.url;
-                
+
                 return L.esri.tiledMapLayer(params.options);
             }
         },
@@ -236,9 +236,9 @@ angular.module("leaflet-directive")
                     $log.warn(errorHeader + ' The esri plugin is not loaded.');
                     return;
                 }
-                
+
                 params.options.url = params.url;
-                
+
                 return L.esri.dynamicMapLayer(params.options);
             }
         },
@@ -250,7 +250,7 @@ angular.module("leaflet-directive")
                     return;
                 }
                  params.options.url = params.url;
-                
+
                 return L.esri.imageMapLayer(params.options);
             }
         },
@@ -464,7 +464,16 @@ angular.module("leaflet-directive")
         return layerTypes[layerDefinition.type].createLayer(params);
     }
 
+    function safeAddLayer(map, layer) {
+        if (layer && typeof layer.addTo === 'function') {
+            layer.addTo(map);
+        } else {
+            map.addLayer(layer);
+        }
+    }
+
     return {
-        createLayer: createLayer
+        createLayer: createLayer,
+        safeAddLayer: safeAddLayer
     };
 });

--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -355,6 +355,12 @@ angular.module("leaflet-directive")
                 return L.imageOverlay(params.url, params.bounds, params.options);
             }
         },
+        iip: {
+            mustHaveUrl: true,
+            createLayer: function(params) {
+                return L.tileLayer.iip(params.url, params.options);
+            }
+        },
 
         // This "custom" type is used to accept every layer that user want to define himself.
         // We can wrap these custom layers like heatmap or yandex, but it means a lot of work/code to wrap the world,


### PR DESCRIPTION
Had to do a small refactoring because the IIP plugin use addTo method with custom logic.
Therefore changed the $watch implementation to use addTo() instead of addLayer().
No change there because the default addTo implementation use addLayer(this)

Also added a new case to the layersHelper switch for creating the IIP layer, tried to use the 'custom' case however using angular.copy on the layer caused problems where the layer did not finished initialization and was already added to the map throwing some exceptions.