### PR TITLE
assign layerOptions first

### DIFF
--- a/src/directives/layers.js
+++ b/src/directives/layers.js
@@ -143,7 +143,8 @@ angular.module("leaflet-directive").directive('layers', function (leafletLogger,
                             // Remove from the map if it's on it
                             if (map.hasLayer(leafletLayers.overlays[name])) {
                                 // Safe remove when ArcGIS layers is loading.
-                                safeRemoveLayer(map, leafletLayers.overlays[name], newOverlayLayers[name].layerOptions);
+                                var layerOptions = isDefined(newOverlayLayers[name]) ? newOverlayLayers[name].layerOptions : null;
+                                safeRemoveLayer(map, leafletLayers.overlays[name], layerOptions);
                             }
                             // TODO: Depending on the layer type we will have to delete what's included on it
                             delete leafletLayers.overlays[name];


### PR DESCRIPTION
One of the preconditions for entering this block is that <b>newOverlayLayer[name]</b> is not defined.  So, it is a mistake to pass a property (layerOptions) of that object to <b>safeRemoveLayer</b> :bug: