### PR TITLE
docs(lfCenter): Change examples and docs from center to lf-center

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ angular.module('myModule').controller('MapController', ['$scope', 'leafletData',
 
 Finally, you must include the markup directive on your HTML page, like this:
 ```html
-<leaflet defaults="defaults" center="center" height="480px" width="640px"></leaflet>
+<leaflet defaults="defaults" lf-center="center" height="480px" width="640px"></leaflet>
 ```
 
 If you want to have more than one map on the page and access their respective map objects, add an *id* attribute to your leaflet directive in HTML, like this:
 
 ```html
-<leaflet id="mymap" defaults="defaults" center="center" height="480px" width="640px"></leaflet>
+<leaflet id="mymap" defaults="defaults" lf-center="center" height="480px" width="640px"></leaflet>
 ```
 
 And then you can use this id in ```getMap()``` like this:

--- a/doc/bounds-attribute.md
+++ b/doc/bounds-attribute.md
@@ -4,7 +4,7 @@
 This sub-directive needs the **leaflet** main directive, so it is normally used as an attribute of the *leaflet* tag, like this:
 
 ```
-<leaflet bounds="bounds" center="center"></leaflet>
+<leaflet bounds="bounds" lf-center="center"></leaflet>
 ```
 
 It will map an object _bounds_ of our controller scope with the corresponding object on our leaflet directive isolated scope. It's a bidirectional relationship, so a change in this object on the controller scope object will affect the map bounds, or an interaction on the map which changes the map position will update our _bounds_ values. Let's define the bounds model with an example:

--- a/doc/center-attribute.md
+++ b/doc/center-attribute.md
@@ -4,7 +4,7 @@
 This sub-directive needs the **leaflet** main directive, so it is normally used as an attribute of the *leaflet* tag, like this:
 
 ```
-<leaflet center="center"></leaflet>
+<leaflet lf-center="center"></leaflet>
 ```
 
 It will map an object _center_ of our controller scope with the corresponding object on our directive isolated scope. It's a bidirectional relationship, so a change in this object on the controller scope will affect the map center position, or an interaction on the map which changes the map center will update our _center_ values. Let's define the center model with an example:
@@ -34,7 +34,7 @@ angular.extend($scope, {
 
 And after that, in our HTML code we will define our leaflet directive like this:
 ```
-<leaflet center="center"></leaflet>
+<leaflet lf-center="center"></leaflet>
 ```
 
 And that's all. A full example of using this attribute can be found [here](http://tombatossals.github.io/angular-leaflet-directive/examples/center-example.html).
@@ -63,7 +63,7 @@ Center position coded on a hash URL param
 ------------------------------------------
 We can use a special feature of the center attribute which allow us to synchronize the center position of the map with the URL, adding to it a special GET parameter where the center is coded. Then we can persist the map position on the browser URL.
 ```
-<leaflet center="center" url-hash-center="yes" />
+<leaflet lf-center="center" url-hash-center="yes" />
 ```
 
 Adding that attribute will synchronize the center with a GET parameter on the URL of this form `?c=lat:lng:zoom`. Furthermore, whenever the map center is changed a new event `urlCenterHash` will be emitted to the parent scope so you can update your `$location.search` with the new info (if you want).

--- a/doc/leaflet-directive.md
+++ b/doc/leaflet-directive.md
@@ -4,7 +4,7 @@ Leaflet directive Documentation
 This directive acts as an intermediary between the AngularJS framework and the Leaflet map management library. It's composed of a main directive **&lt;leaflet&gt;** and attributes (coded as sub-directives) of the main directive. For example, we could add to our HTML code:
 
 ```
-<leaflet center="center" width="640px" height="480px">
+<leaflet lf-center="center" width="640px" height="480px">
 ```
 
 Here we have the main **leaflet** directive, with the attribute **center** and two more attributes (without bi-directional binding) **width** and **height**.

--- a/examples/0101-basic-center-example.html
+++ b/examples/0101-basic-center-example.html
@@ -27,7 +27,7 @@
     </style>
   </head>
   <body ng-controller="BasicCenterController">
-     <leaflet center="london" width="100%" height="480px"></leaflet>
+     <leaflet lf-center="london" width="100%" height="480px"></leaflet>
      <h1>Center map example</h1>
      <ul>
          <li><input type="number" step="any" ng-model="london.lat" /> Latitude</li>

--- a/examples/0102-basic-center-autodiscover-example.html
+++ b/examples/0102-basic-center-autodiscover-example.html
@@ -24,7 +24,7 @@
     </style>
   </head>
   <body ng-controller="BasicCenterAutodiscoverController">
-    <leaflet center="center" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" width="100%" height="480px"></leaflet>
     <h1>Center autodiscover example</h1>
     <ul>
         <li><input type="number" step="any" ng-model="center.lat" /> Latitude</li>

--- a/examples/0103-basic-center-url-hash-example.html
+++ b/examples/0103-basic-center-url-hash-example.html
@@ -35,7 +35,7 @@
     </style>
   </head>
   <body ng-controller="BasicCenterUrlHashController">
-      <leaflet center="london" url-hash-center="yes" width="100%" height="480px"></leaflet>
+      <leaflet lf-center="london" url-hash-center="yes" width="100%" height="480px"></leaflet>
       <h1>Center map with URL synchronization example</h1>
       <p>This demo syncs the map center position with the URL, and vice versa, using the <strong>center-url-params</strong> property.</p>
       <ul>

--- a/examples/0104-basic-custom-parameters-example.html
+++ b/examples/0104-basic-custom-parameters-example.html
@@ -30,7 +30,7 @@
     </script>
   </head>
   <body ng-controller="BasicCustomParametersController">
-    <leaflet center="london" defaults="defaults" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" defaults="defaults" width="100%" height="480px"></leaflet>
     <h1>Using custom default parameters</h1>
   </body>
 </html>

--- a/examples/0105-basic-bounds-example.html
+++ b/examples/0105-basic-bounds-example.html
@@ -25,7 +25,7 @@
     </script>
   </head>
   <body ng-controller="BasicBoundsController">
-    <leaflet bounds="bounds" center="center" width="100%" height="480px"></leaflet>
+    <leaflet bounds="bounds" lf-center="center" width="100%" height="480px"></leaflet>
     <h1>Map bounds example</h1>
     <h2>South west</h2>
     <form>

--- a/examples/0107-basic-tiles-example.html
+++ b/examples/0107-basic-tiles-example.html
@@ -58,7 +58,7 @@
     </script>
   </head>
   <body ng-controller="BasicTilesController">
-      <leaflet center="london" tiles="tiles" defaults="defaults" width="100%" height="480px"></leaflet>
+      <leaflet lf-center="london" tiles="tiles" defaults="defaults" width="100%" height="480px"></leaflet>
       <h1>Changing tiles example</h1>
       <p>Change tiles clicking in the buttons below:</p>
       <p>

--- a/examples/0108-basic-tiles-zoom-changer-example.html
+++ b/examples/0108-basic-tiles-zoom-changer-example.html
@@ -32,7 +32,7 @@
     </script>
   </head>
   <body ng-controller="BasicTilesZoomChangerController">
-      <leaflet center="london" tiles="tiles" width="100%" height="480px"></leaflet>
+      <leaflet lf-center="london" tiles="tiles" width="100%" height="480px"></leaflet>
       <h1>Dynamic tile changer based on zoom level</h1>
       <p>Zoom to level 13 to see how the tiles change:</p>
       <ul>

--- a/examples/0109-basic-center-geoip-example.html
+++ b/examples/0109-basic-center-geoip-example.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <body ng-controller="BasicCenterGeoIPController">
-    <leaflet center="center" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" width="100%" height="480px"></leaflet>
     <h1>Center by IP (GeoIP) example</h1>
     <p>Insert the IP you want to know its location:</p>
     <form>

--- a/examples/0110-basic-map-without-animations-example.html
+++ b/examples/0110-basic-map-without-animations-example.html
@@ -31,7 +31,7 @@
     </script>
   </head>
   <body ng-controller="BasicMapWithoutAnimationsController">
-    <leaflet center="london" defaults="defaults" markers="markers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" defaults="defaults" markers="markers" width="100%" height="480px"></leaflet>
     <h1>Map with disabled animations example</h1>
   </body>
 </html>

--- a/examples/0111-basic-legend-example.html
+++ b/examples/0111-basic-legend-example.html
@@ -47,7 +47,7 @@
     </script>
   </head>
   <body ng-controller="BasicLegendController">
-    <leaflet center="london" legend="legend" defaults="defaults" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" legend="legend" defaults="defaults" width="100%" height="480px"></leaflet>
     <h1>Legend example</h1>
   </body>
 </html>

--- a/examples/0112-basic-maxbounds-pad-example.html
+++ b/examples/0112-basic-maxbounds-pad-example.html
@@ -55,7 +55,7 @@
 </head>
 
 <body ng-controller="BasicMaxBoundsPadController">
-    <leaflet center="center" layers="layers" markers="markers" maxbounds="maxbounds" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" markers="markers" maxbounds="maxbounds" width="100%" height="480px"></leaflet>
     <h1>Extend Maxbounds with Pad</h1>
     <p>You can extend maxbounds with a pad property. <a href=http://leafletjs.com/reference.html#latlngbounds-pad>Pad</a> is a percentage by which the latLngBounds will be extended.</p>
     <pre ng-bind="maxbounds | json"></pre>

--- a/examples/0113-basic-geojson-simple-example.html
+++ b/examples/0113-basic-geojson-simple-example.html
@@ -40,7 +40,7 @@
       </script>
   </head>
   <body ng-controller="GeoJSONController">
-     <leaflet center="japan" geojson="geojson" defaults="defaults" width="100%" height="480px"></leaflet>
+     <leaflet lf-center="japan" geojson="geojson" defaults="defaults" width="100%" height="480px"></leaflet>
      <h1>Simple GeoJSON example</h1>
   </body>
 </html>

--- a/examples/0114-basic-geojson-center-example.html
+++ b/examples/0114-basic-geojson-center-example.html
@@ -56,7 +56,7 @@
       </script>
   </head>
   <body ng-controller="GeoJSONCenterController">
-     <leaflet center="japan" geojson="geojson" defaults="defaults" width="100%" height="480px"></leaflet>
+     <leaflet lf-center="japan" geojson="geojson" defaults="defaults" width="100%" height="480px"></leaflet>
      <h1>Center to GeoJSON example</h1>
      <input type="button" value="Click to center" ng-click="centerJSON()" />
   </body>

--- a/examples/0115-basic-events-example.html
+++ b/examples/0115-basic-events-example.html
@@ -28,7 +28,7 @@
     </script>
   </head>
   <body ng-controller="BasicEventsController">
-    <leaflet center="center" width="100%" height="400px"></leaflet>
+    <leaflet lf-center="center" width="100%" height="400px"></leaflet>
     <h1>Events example</h1>
     <p>All map events are propagated by default.</p>
     <ul>

--- a/examples/0116-basic-access-leaflet-object-example.html
+++ b/examples/0116-basic-access-leaflet-object-example.html
@@ -32,7 +32,7 @@
     </style>
   </head>
   <body ng-controller="BasicAccessLeafletObjectController">
-    <leaflet center="london" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" width="100%" height="480px"></leaflet>
     <h1>Direct access to the Leaflet Map Object</h1>
     <p><button ng-click="fitBounds()">Fitbounds outside leaflet-directive!</button></p>
     <form>

--- a/examples/0118-basic-double-map-events-example.html
+++ b/examples/0118-basic-double-map-events-example.html
@@ -81,10 +81,10 @@
     <h1>Different map events broadcasting</h1>
     <p>We can filter which leaflet events we propagate upwars using the event-broadcast directive property, let's see how it works:</p>
     <h3>This map propagates all events</h3>
-    <leaflet event-broadcast="events" center="london" markers="markers" width="100%" height="320px" defaults="defaults"></leaflet>
+    <leaflet event-broadcast="events" lf-center="london" markers="markers" width="100%" height="320px" defaults="defaults"></leaflet>
     <p>Event: <strong ng-bind="eventDetected"></strong></p>
     <h3>This map propagates the "click" and "dblclick" events</h3>
-    <leaflet center="spain" event-broadcast="events2" markers="markers2" width="100%" height="320px"></leaflet>
+    <leaflet lf-center="spain" event-broadcast="events2" markers="markers2" width="100%" height="320px"></leaflet>
     <p>Event: <strong ng-bind="eventDetected2"></strong></p>
   </body>
 </html>

--- a/examples/0119-basic-double-map-access-map-object-example.html
+++ b/examples/0119-basic-double-map-access-map-object-example.html
@@ -43,10 +43,10 @@
   </head>
   <body ng-controller="BasicDoubleMapAccessMapObjectController">
     <div style="float:left; width: 50%;">
-      <leaflet center="london" markers="markers" width="100%" height="300px" defaults="defaults" id="map1"></leaflet>
+      <leaflet lf-center="london" markers="markers" width="100%" height="300px" defaults="defaults" id="map1"></leaflet>
     </div>
     <div style="float:left; width: 50%;">
-      <leaflet center="london" markers="markers" width="100%" height="300px" id="map2"></leaflet>
+      <leaflet lf-center="london" markers="markers" width="100%" height="300px" id="map2"></leaflet>
     </div>
 
     <h1>Accesing the map object with two (or more) maps on screen</h1>

--- a/examples/0120-basic-double-map-sharing-attributes-example.html
+++ b/examples/0120-basic-double-map-sharing-attributes-example.html
@@ -58,10 +58,10 @@
   </head>
   <body ng-controller="BasicDoubleMapSharingAttributesController">
     <div style="float: left; width: 50%;">
-        <leaflet id="map1" geojson="toronto1" defaults="defaults" markers="markers1" center="center" width="100%" height="320px"></leaflet>
+        <leaflet id="map1" geojson="toronto1" defaults="defaults" markers="markers1" lf-center="center" width="100%" height="320px"></leaflet>
     </div>
     <div style="float: left; width: 50%;">
-        <leaflet id="map2" geojson="toronto2" defaults="defaults" markers="markers2" center="center" width="100%" height="320px"></leaflet>
+        <leaflet id="map2" geojson="toronto2" defaults="defaults" markers="markers2" lf-center="center" width="100%" height="320px"></leaflet>
     </div>
     <h1>Two maps sharing center example</h1>
     <p>Drag the center in any of the maps</p>

--- a/examples/0121-basic-double-map-toggle-example.html
+++ b/examples/0121-basic-double-map-toggle-example.html
@@ -75,8 +75,8 @@
     </script>
   </head>
   <body ng-controller="BasicDoubleMapToggleController">
-    <leaflet ng-if="togglemap" id="map1" center="center" paths="paths" width="100%" height="480px"></leaflet>
-    <leaflet ng-if="!togglemap" id="map2" center="center2" tiles="tiles2" paths="paths2" width="100%" height="480px"></leaflet>
+    <leaflet ng-if="togglemap" id="map1" lf-center="center" paths="paths" width="100%" height="480px"></leaflet>
+    <leaflet ng-if="!togglemap" id="map2" lf-center="center2" tiles="tiles2" paths="paths2" width="100%" height="480px"></leaflet>
     <h1>Toggle between two maps on screen</h1>
     <p>View javascript console while toggling map</p>
     <button ng-click="togglemap = !togglemap">Toggle Map</button>

--- a/examples/0122-basic-geojson-update-example.html
+++ b/examples/0122-basic-geojson-update-example.html
@@ -105,7 +105,7 @@
               </script>
           </head>
     <body ng-controller="BasicGeoJSONUpdateController">
-        <leaflet center="center" geojson="geojson" width="100%" height="480px"></leaflet>
+        <leaflet lf-center="center" geojson="geojson" width="100%" height="480px"></leaflet>
         <h1>GeoJSON update example</h1>
         <button ng-click="updateGeojson()">update GeoJSON</button>
     </body>

--- a/examples/0123-basic-hide-show-map-example.html
+++ b/examples/0123-basic-hide-show-map-example.html
@@ -29,7 +29,7 @@
     </script>
   </head>
   <body ng-controller="BasicHideShowMapController">
-    <leaflet ng-show="showMap" width="100%" height="320px" center="center"></leaflet>
+    <leaflet ng-show="showMap" width="100%" height="320px" lf-center="center"></leaflet>
     <h1>Hide/Show map example</h1>
     <p>Select to show the map <input type="checkbox" ng-model="showMap"></p>
     <p>Center: {{ center }}</p>

--- a/examples/0124-basic-geojson-non-nested-example.html
+++ b/examples/0124-basic-geojson-non-nested-example.html
@@ -75,7 +75,7 @@
     </script>
 </head>
 <body ng-controller="GeoJSONNonNestedController">
-    <leaflet center="japan" geojson="geojson" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="japan" geojson="geojson" width="100%" height="480px"></leaflet>
     <h1>GeoJSON non nested example</h1>
     <input type="button" value="center usa" ng-click="centerJSON(1)" />
     <input type="button" value="center jpn" ng-click="centerJSON(0)" />

--- a/examples/0125-basic-geojson-nested-example.html
+++ b/examples/0125-basic-geojson-nested-example.html
@@ -95,7 +95,7 @@
     </script>
 </head>
 <body ng-controller="GeoJSONNestedController">
-    <leaflet center="japan" geojson="geojson" geojson-nested="true" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="japan" geojson="geojson" geojson-nested="true" width="100%" height="480px"></leaflet>
     <h1>GeoJSON nested example</h1>
     <input type="button" value="center usa" ng-click="centerJSON('usa')" />
     <input type="button" value="center jpn" ng-click="centerJSON('japan')" />

--- a/examples/0201-layers-simple-example.html
+++ b/examples/0201-layers-simple-example.html
@@ -44,7 +44,7 @@
     </script>
 </head>
 <body ng-controller="LayersSimpleController">
-    <leaflet center="center" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Layers simple example</h1>
     <p>You can easily add various layers to your map, including a layer selector on the top right, defining <strong>layers</strong> object.</p>
 </body>

--- a/examples/0202-layers-overlays-simple-example.html
+++ b/examples/0202-layers-overlays-simple-example.html
@@ -42,7 +42,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlaysSimpleController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Baselayer with overlays</h1>
     <p>You can add overlays to a baselayer, which will show a layer selector on the top right corner, defining <strong>layers</strong> like in this example.</p>
 </body>

--- a/examples/0203-layers-imageoverlay-example.html
+++ b/examples/0203-layers-imageoverlay-example.html
@@ -42,7 +42,7 @@
     </script>
   </head>
   <body ng-controller="LayersImageOverlayController">
-    <leaflet center="center" defaults="defaults" layers="layers" maxBounds="maxBounds" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="center" defaults="defaults" layers="layers" maxBounds="maxBounds" height="480px" width="100%"></leaflet>
     <h1>Layer with image overlay and maxBounds</h1>
   </body>
 </html>

--- a/examples/0204-layers-dynamic-addition-example.html
+++ b/examples/0204-layers-dynamic-addition-example.html
@@ -81,7 +81,7 @@
     </script>
 </head>
 <body ng-controller="LayersDynamicAdditionController">
-    <leaflet center="bern" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="bern" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Dynamic addition/removal of layers</h1>
     <button type="button" ng-if="layers.baselayers['mapbox_wheat']" ng-click="toggleLayer('mapbox_wheat')">Remove Mapbox Wheat Layer</button>
     <button type="button" ng-if="!layers.baselayers['mapbox_wheat']" ng-click="toggleLayer('mapbox_wheat')">Add Mapbox Wheat Layer</button>

--- a/examples/0205-layers-googlemaps-example.html
+++ b/examples/0205-layers-googlemaps-example.html
@@ -48,7 +48,7 @@
     </script>
 </head>
 <body ng-controller="GoogleMapsController">
-    <leaflet center="berlin" layers="layers" markers="markers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="berlin" layers="layers" markers="markers" height="480px" width="100%"></leaflet>
     <h1>Google maps example</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to select another Google Maps Layer.</p>
 </body>

--- a/examples/0206-layers-googlemaps-fullsize-example.html
+++ b/examples/0206-layers-googlemaps-fullsize-example.html
@@ -64,7 +64,7 @@
 </head>
 <body ng-controller="GoogleMapsFullsizeController">
     <div class="fullscreen">
-        <leaflet center="berlin" layers="layers" markers="markers" width="100%" height="100%"></leaflet>
+        <leaflet lf-center="berlin" layers="layers" markers="markers" width="100%" height="100%"></leaflet>
     </div>
     <h1>Google Maps fullsize example</h1>
     <p>Open this example as stand-alone page with the bottom link to see how it fullscreens your monitor</p>

--- a/examples/0207-layers-hide-baselayer-on-selector-example.html
+++ b/examples/0207-layers-hide-baselayer-on-selector-example.html
@@ -45,7 +45,7 @@
     </script>
 </head>
 <body ng-controller="LayersHideBaselayerOnSelectorController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Baselayer hidden on switch selector to show only overlay</h1>
     <p>Open the layer switch selector to see it.</p>
     <pre ng-bind="layers | json"></pre>

--- a/examples/0208-layers-esri-dynamic-layer-example.html
+++ b/examples/0208-layers-esri-dynamic-layer-example.html
@@ -54,7 +54,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriDynamicLayerController">
-    <leaflet center="bogota" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="bogota" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Dynamic Map Layer</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to select another Esri Layer.</p>
 </body>

--- a/examples/0209-layers-esri-legend-service-example.html
+++ b/examples/0209-layers-esri-legend-service-example.html
@@ -142,7 +142,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriLegendServiceController">
-    <leaflet center="usa" layers="layers" markers="markers" height="480px" width="100%"
+    <leaflet lf-center="usa" layers="layers" markers="markers" height="480px" width="100%"
         legend="legend" defaults="options"></leaflet>
     <h1>Esri ArcGIS Legend Service</h1>
     <p>Use the button to switch another Esri Legend.</p>

--- a/examples/0210-layers-webgl-heatmap-example.html
+++ b/examples/0210-layers-webgl-heatmap-example.html
@@ -43,7 +43,7 @@
     </script>
 </head>
 <body ng-controller="LayersWebGLHeatmapController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>HeatMap WebGL overlay example</h1>
     <p>You can use the <a href="https://github.com/ursudio/webgl-heatmap-leaflet">WebGL HeatMap overlay plugin</a>, like this. Please read the heatmap plugin documentation to use it.</p>
     <pre ng-bind="layers | json"></pre>

--- a/examples/0211-layers-layergroup-simple-example.html
+++ b/examples/0211-layers-layergroup-simple-example.html
@@ -70,7 +70,7 @@
     </script>
 </head>
 <body ng-controller="LayersLayergroupSimpleController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Layer Groups with nested layer definitions</h1>
     <p>You can add layer groups to a map.  In this case, a UTF Grid and Tile Layer are grouped.  Notice that the layers show as one in the layer selector control.</p>
     <p ng-if=country>You hovered over: <b ng-bind=country></b></p>

--- a/examples/0212-layers-hide-overlays-on-selector-example.html
+++ b/examples/0212-layers-hide-overlays-on-selector-example.html
@@ -51,7 +51,7 @@
     </script>
 </head>
 <body ng-controller="LayersHideOverlaysOnSelectorController">
-    <leaflet center="center" defaults="defaults" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" defaults="defaults" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Overlay not shown in selector</h1>
     <button ng-click="layers.overlays.wms.layerParams.showOnSelector = !layers.overlays.wms.layerParams.showOnSelector">Toggle Overlay visibility on Selector</button>
     <button ng-click="layers.baselayers.xyz.layerOptions.showOnSelector = !layers.baselayers.xyz.layerOptions.showOnSelector">Toggle BaseLayer visibility on Selector</button>

--- a/examples/0213-layers-bingmaps-example.html
+++ b/examples/0213-layers-bingmaps-example.html
@@ -57,7 +57,7 @@
     </script>
 </head>
 <body ng-controller="LayersBingMapsController">
-    <leaflet center="bastia" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="bastia" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
     <h1>Bing maps</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to select another Bing Maps Layer.</p>
 </body>

--- a/examples/0214-layers-utfgrid-example.html
+++ b/examples/0214-layers-utfgrid-example.html
@@ -53,7 +53,7 @@
     </style>
 </head>
 <body ng-controller="LayersUTFGridController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Baselayer with UTFGrid interactivity in Overlay</h1>
     <p>Mouse over the map regions to interact with UTFGrid.</p>
     <h2>{{interactivity}}</h2>

--- a/examples/0216-layers-overlays-markercluster-example.html
+++ b/examples/0216-layers-overlays-markercluster-example.html
@@ -106,7 +106,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlaysMarkerclusterController">
-    <leaflet center="ripoll" markers="markers" layers="layers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="ripoll" markers="markers" layers="layers" height="480px" width="100%"></leaflet>
     <h1>This is a map with overlays and a markercluster</h1>
     <p>
     In this example we use a <a href="https://github.com/Leaflet/Leaflet.markercluster">MarkerCluster</a> overlay to group the markers instead of a LayerGroup.

--- a/examples/0218-layers-overlays-markers-nested-example.html
+++ b/examples/0218-layers-overlays-markers-nested-example.html
@@ -155,7 +155,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlaysMarkersNestedController">
-    <leaflet center="ripoll"
+    <leaflet lf-center="ripoll"
              markers="markers"
              layers="layers"
              markers-nested="true"

--- a/examples/0219-layers-overlays-paths-example.html
+++ b/examples/0219-layers-overlays-paths-example.html
@@ -169,7 +169,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlaysPathsController">
-    <leaflet center="cen" markers="markers" paths="paths" layers="layers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="cen" markers="markers" paths="paths" layers="layers" height="480px" width="100%"></leaflet>
     <h1>Different overlays for paths</h1>
     <p>
     In this example we create two layer groups lines, and shapes. We insert markers in both layers (note that on is initially

--- a/examples/0220-layers-wms-with-different-projection-example.html
+++ b/examples/0220-layers-wms-with-different-projection-example.html
@@ -54,6 +54,6 @@
   </head>
   <body ng-controller="LayersWMSWithDifferentProjectionController">
     <h1>Load a map in non standard projection</h1>
-    <leaflet center="map.malmo" defaults="map.defaults" layers="map.layers" width="100%" height="400px"></leaflet>
+    <leaflet lf-center="map.malmo" defaults="map.defaults" layers="map.layers" width="100%" height="400px"></leaflet>
   </body>
 </html>

--- a/examples/0221-layers-heatmap-example.html
+++ b/examples/0221-layers-heatmap-example.html
@@ -59,7 +59,7 @@
 </head>
 
 <body ng-controller="LayersHeatmapController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>HeatMap example</h1>
     <p>This example uses the <a href="https://github.com/Leaflet/Leaflet.heat">Leaflet.heat</a> library.</p>
     <p>The example is inspired in <a href="https://developers.google.com/maps/documentation/javascript/examples/layer-heatmap?hl=es">this</a> Google Maps Heat example.</p>

--- a/examples/0222-layers-overlays-hide-on-zoomout-example.html
+++ b/examples/0222-layers-overlays-hide-on-zoomout-example.html
@@ -46,7 +46,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlaysHideOnZoomOutController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Baselayer with overlay which is hidden on Zoom less than 4 </h1>
     <p>
       zoom: {{center.zoom}}

--- a/examples/0223-layers-refresh-overlay-every-minute-example.html
+++ b/examples/0223-layers-refresh-overlay-every-minute-example.html
@@ -55,7 +55,7 @@
     </script>
 </head>
 <body ng-controller="LayersRefreshOverlayEveryMinuteController">
-    <leaflet center="amberes" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="amberes" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Refreshable overlays example</h1>
     <p>You can refresh the overlay/baselayer state adding a boolean property to the layer:</p>
     <pre>

--- a/examples/0224-layers-esri-base-layer-example.html
+++ b/examples/0224-layers-esri-base-layer-example.html
@@ -86,7 +86,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriBaseMapLayerController">
-    <leaflet center="bogota" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="bogota" layers="layers" markers="markers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Basemap Layer</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to select another Esri Basemap Layer.</p>
 </body>

--- a/examples/0225-layers-esri-feature-layer-example.html
+++ b/examples/0225-layers-esri-feature-layer-example.html
@@ -239,7 +239,7 @@
             float: right;
         }
     </style>
-    <leaflet center="porland" layers="layers" width="100%" height="480px">
+    <leaflet lf-center="porland" layers="layers" width="100%" height="480px">
         <layercontrol order="normal" icons="layercontrol.icons" auto-hide-opacity="true" show-groups="false"
             title="Layer Manager" base-title="Base Layers" overlays-title="Overlays Layers"></layercontrol>
     </leaflet>

--- a/examples/0226-layers-esri-tiled-map-layer-example.html
+++ b/examples/0226-layers-esri-tiled-map-layer-example.html
@@ -39,7 +39,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriTiledMapLayerController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Tiled Map Layer</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to show another Esri Tiled Map Layers.</p>
 </body>

--- a/examples/0227-layers-esri-image-layer-example.html
+++ b/examples/0227-layers-esri-image-layer-example.html
@@ -44,7 +44,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriImageLayerController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Image Layer</h1>
     <p>
         Display NAIP imagery from an ArcGIS image service and use the band IDs parameter to show the near infrared band in a

--- a/examples/0228-layers-esri-clustered-layer-example.html
+++ b/examples/0228-layers-esri-clustered-layer-example.html
@@ -44,7 +44,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriClusteredLayerController">
-    <leaflet center="porland" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="porland" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Clustered Layer</h1>
     <p>
         Visualize dense services as clusters of points with the

--- a/examples/0229-layers-esri-heatmap-layer-example.html
+++ b/examples/0229-layers-esri-heatmap-layer-example.html
@@ -52,7 +52,7 @@
     </script>
 </head>
 <body ng-controller="LayersEsriHeatmapLayerController">
-    <leaflet center="center" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Esri ArcGIS Heatmap Layer</h1>
     <p>
         Displaying point data as a heatmap using the L.heat plugin with custom styling of heatmap gradients with the L.heat options.

--- a/examples/0230-layers-yandex-example.html
+++ b/examples/0230-layers-yandex-example.html
@@ -50,7 +50,7 @@
     </script>
 </head>
 <body ng-controller="LayersYandexController">
-    <leaflet center="berlin" layers="layers" markers="markers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="berlin" layers="layers" markers="markers" height="480px" width="100%"></leaflet>
     <h1>Yandex layer example</h1>
     <p>Use the Layer Switch Control on the top rigth of the map to select another Yandex Layer.</p>
 </body>

--- a/examples/0231-layers-overlay-geojson-example.html
+++ b/examples/0231-layers-overlay-geojson-example.html
@@ -72,7 +72,7 @@
     </script>
 </head>
 <body ng-controller="LayersOverlayGeoJSONController">
-    <leaflet center="world" layers="layers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="world" layers="layers" height="480px" width="100%"></leaflet>
     <h1>GeoJSON Shape Layer and GeoJSON Awesome Marker Layer</h1>
     <p>Use the layer control to add a geoJSON shape layer. This is different from a GeoJSON layer, which is a Tile Layer</p>
     <p>The example also includes a geoJSON Awesome Markers layer, which you can use to customise marker icons easily.</p>

--- a/examples/0300-paths-simple-example.html
+++ b/examples/0300-paths-simple-example.html
@@ -44,7 +44,7 @@
     </script>
   </head>
   <body ng-controller="PathSimpleController">
-    <leaflet center="london" paths="europeanPaths" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" paths="europeanPaths" width="100%" height="480px"></leaflet>
     <h1>Paths simple example</h1>
     <p>Click on red route (Popup) or hover over green route (Label) to get more information</p>
   </body>

--- a/examples/0301-paths-types-example.html
+++ b/examples/0301-paths-types-example.html
@@ -99,7 +99,7 @@
     </script>
   </head>
   <body ng-controller="PathTypesController">
-      <leaflet center="center" paths="paths" width="100%" height="480px"></leaflet>
+      <leaflet lf-center="center" paths="paths" width="100%" height="480px"></leaflet>
       <h1>Types of paths</h1>
 
       <button type="button" ng-click="addShape('polyline')" class="btn btn-default">polyline</button>

--- a/examples/0302-paths-ajax-load-example.html
+++ b/examples/0302-paths-ajax-load-example.html
@@ -38,7 +38,7 @@
     </script>
   </head>
   <body ng-controller="PathsAjaxLoadController">
-    <leaflet center="london" paths="europeanPaths" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" paths="europeanPaths" width="100%" height="480px"></leaflet>
     <h1>Load remote paths example</h1>
     <p>Click on red route (Popup) or hover over green route (Label) to get more information</p>
     <button ng-click="loadPaths()">Load Paths data!</button>

--- a/examples/0303-paths-3000-items-example.html
+++ b/examples/0303-paths-3000-items-example.html
@@ -140,7 +140,7 @@
     </script>
   </head>
   <body ng-controller="Paths3000ItemsController">
-      <leaflet watch-paths="false" center="centroid" maxbounds="maxbounds" layers="layers" paths="paths" defaults="defaults" width="100%" height="480px"></leaflet>
+      <leaflet watch-paths="false" lf-center="centroid" maxbounds="maxbounds" layers="layers" paths="paths" defaults="defaults" width="100%" height="480px"></leaflet>
       <h1>3000 items in a map performance</h1>
   </body>
 </html>

--- a/examples/0304-paths-advanced-example.html
+++ b/examples/0304-paths-advanced-example.html
@@ -154,7 +154,7 @@
         </script>
     </head>
     <body ng-controller="PathsAdvancedController">
-        <leaflet center="cen" markers="markers" paths="paths"></leaflet>
+        <leaflet lf-center="cen" markers="markers" paths="paths"></leaflet>
         <h1>Advanced Paths Example</h1>
         <div id="control">
             <div class="panel">

--- a/examples/0305-paths-change-in-group-layer-example.html
+++ b/examples/0305-paths-change-in-group-layer-example.html
@@ -59,7 +59,7 @@
     </script>
   </head>
   <body ng-controller="PathsChangeInGroupLayerController">
-      <leaflet width="100%" height="400px" center="center" paths="paths" layers="layers"></leaflet>
+      <leaflet width="100%" height="400px" lf-center="center" paths="paths" layers="layers"></leaflet>
       <h1>Path change in group layer</h1>
       <p><button ng-click="changePaths()">Change Paths</button></p>
   </body>

--- a/examples/0306-paths-decorations-simple-example.html
+++ b/examples/0306-paths-decorations-simple-example.html
@@ -77,7 +77,7 @@
     </script>
   </head>
   <body ng-controller="PathsDecorationsSimpleController">
-    <leaflet center="london" decorations="decorations" height="480px" width="640px"></leaflet>
+    <leaflet lf-center="london" decorations="decorations" height="480px" width="640px"></leaflet>
     <h1>Path decoration example</h1>
     <button ng-click="changePattern('slash')">Slash pattern</button>
     <button ng-click="changePattern('dot')">Dot pattern</button>

--- a/examples/0307-paths-events-example.html
+++ b/examples/0307-paths-events-example.html
@@ -77,7 +77,7 @@
     </script>
   </head>
   <body ng-controller="PathEventsController">
-    <leaflet center="center" paths="paths" layers="layers" event-broadcast="events" paths="paths" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" paths="paths" layers="layers" event-broadcast="events" paths="paths" width="100%" height="480px"></leaflet>
     <h1>Paths specific events propagation exampl</h1>
     <p>Click on path points to trigger an event</p>
     <p>Mouse over: <strong ng-bind="mouseover"></strong></p>

--- a/examples/0400-controls-custom-layer-control-example.html
+++ b/examples/0400-controls-custom-layer-control-example.html
@@ -194,7 +194,7 @@
             float: right;
         }
     </style>
-    <leaflet center="madrid" layers="layers" height="480px" width="100%">
+    <leaflet lf-center="madrid" layers="layers" height="480px" width="100%">
         <layercontrol order="normal" icons="layercontrol.icons" auto-hide-opacity="true" show-groups="true"
             title="Layer Manager" base-title="Base Layers" overlays-title="Overlays Layers"></layercontrol>
     </leaflet>

--- a/examples/0401-controls-draw-example.html
+++ b/examples/0401-controls-draw-example.html
@@ -68,7 +68,7 @@
     </style>
   </head>
   <body ng-controller="ControlsDrawController">
-    <leaflet center="london" controls="controls" layers="layers" width="100%" height="400"></leaflet>
+    <leaflet lf-center="london" controls="controls" layers="layers" width="100%" height="400"></leaflet>
     <h1>Draw control example</h1>
     <p>Draw a shape and a geoJSON data structure will be shown on the console.log.</p>
   </body>

--- a/examples/0402-controls-scale-example.html
+++ b/examples/0402-controls-scale-example.html
@@ -23,7 +23,7 @@
     </script>
   </head>
   <body ng-controller="ControlsScaleController">
-    <leaflet center="london" controls="controls" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" controls="controls" width="100%" height="480px"></leaflet>
     <h1>Scale control example</h1>
   </body>
 </html>

--- a/examples/0403-controls-fullscreen-example.html
+++ b/examples/0403-controls-fullscreen-example.html
@@ -37,7 +37,7 @@
     </script>
   </head>
   <body ng-controller="ControlsFullscreenController">
-    <leaflet center="london" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
     <h1>Fullscreen control example</h1>
     <p>Fullscreen control with the <a href="https://github.com/Leaflet/Leaflet.fullscreen">Leaflet fullscreen</a> plugin.</p>
   </body>

--- a/examples/0404-controls-minimap-example.html
+++ b/examples/0404-controls-minimap-example.html
@@ -51,7 +51,7 @@
     </script>
   </head>
   <body ng-controller="ControlsMinimapController">
-    <leaflet center="bogota" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="bogota" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
     <h1>Minimap control example</h1>
     <p>Minimap control with the <a href="https://github.com/Norkart/Leaflet-MiniMap">Leaflet minimap</a> plugin.</p>
   </body>

--- a/examples/0405-controls-search-example.html
+++ b/examples/0405-controls-search-example.html
@@ -103,7 +103,7 @@
     </script>
   </head>
   <body ng-controller="ControlsSearchController">
-    <leaflet center="center" controls="controls" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" controls="controls" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Search control example</h1>
     <p>Search for any of the marker names (mouseover to see the name). This is a simple example of use of <a href="http://labs.easyblog.it/maps/leaflet-search/">Leaflet search</a> plugin.</p>
   </body>

--- a/examples/0406-controls-custom-example.html
+++ b/examples/0406-controls-custom-example.html
@@ -35,7 +35,7 @@
     </script>
   </head>
   <body ng-controller="ControlsFullscreenController">
-    <leaflet center="london" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="london" controls="controls" tiles="tiles" width="100%" height="480px"></leaflet>
     <h1>Fullscreen control example</h1>
     <p>Fullscreen control with the <a href="https://github.com/Leaflet/Leaflet.fullscreen">Leaflet fullscreen</a> plugin.</p>
   </body>

--- a/examples/0500-markers-simple-example.html
+++ b/examples/0500-markers-simple-example.html
@@ -47,9 +47,9 @@
     </script>
   </head>
   <body ng-controller="MarkersSimpleController">
-    <!-- <leaflet center="london" markers="markers" height="480px" width="100%"></leaflet> EVENTS WILL STILL FIRE but all will for each directive--> 
+    <!-- <leaflet lf-center="london" markers="markers" height="480px" width="100%"></leaflet> EVENTS WILL STILL FIRE but all will for each directive--> 
     <!-- NOTICE events attribute is optional it is more for options in whitelisting (enable), blacklisting (disable), and logic (emit or broadcast)  -->
-    <leaflet center="london" event-broadcast="events" markers="markers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="london" event-broadcast="events" markers="markers" height="480px" width="100%"></leaflet>
     <h1>Markers simple example</h1>
     <p>Initial marker position (lat/lng): <strong ng-bind="markers.mainMarker.lat"></strong> / <strong ng-bind="markers.mainMarker.lng"></strong></p>
     <p>Actual marker position (lat/lng): <strong  ng-bind="position.lat"></strong> / <strong ng-bind="position.lng"></strong></p>

--- a/examples/0501-markers-events-add-example.html
+++ b/examples/0501-markers-events-add-example.html
@@ -33,7 +33,7 @@
     </script>
   </head>
   <body ng-controller="MarkersEventsAddController">
-      <leaflet center="london" markers="markers" event-broadcast="events" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="london" markers="markers" event-broadcast="events" height="480px" width="100%"></leaflet>
       <h1>Markers with events example</h1>
       <p>Click on the map to add a marker</p>
       </leaflet>

--- a/examples/0502-markers-add-remove-example.html
+++ b/examples/0502-markers-add-remove-example.html
@@ -46,7 +46,7 @@
     </script>
   </head>
   <body ng-controller="MarkersAddRemoveController">
-      <leaflet center="london" markers="markers" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="london" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Add/remove markers easily example</h1>
       <button ng-click="removeMarkers()">Remove markers</button>
       <button ng-click="addMarkers()">Add markers</button>

--- a/examples/0503-markers-icons-example.html
+++ b/examples/0503-markers-icons-example.html
@@ -86,7 +86,7 @@
     </style>
   </head>
   <body ng-controller="MarkersIconsController">
-      <leaflet center="chicago" markers="markers" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="chicago" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Changing the marker icons</h1>
       <p>You can change the marker icons, using the default Leaflet marker icons functions, or using helper libraries like AwesomeMarkers, MakiMarkers or ExtraMarker.</p>
 

--- a/examples/0504-markers-popup-example.html
+++ b/examples/0504-markers-popup-example.html
@@ -43,7 +43,7 @@
     </script>
   </head>
   <body ng-controller="MarkersPopupController">
-    <leaflet center="london" markers="markers" event-broadcast="events" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="london" markers="markers" event-broadcast="events" height="480px" width="100%"></leaflet>
     <h1>Marker Popup properties</h1>
     <h3>Marker position</h3>
         Latitude: <input ng-model="markers.m1.lat" type="number" />

--- a/examples/0505-markers-label-example.html
+++ b/examples/0505-markers-label-example.html
@@ -41,7 +41,7 @@
     </script>
   </head>
   <body ng-controller="MarkersLabelController">
-      <leaflet center="london" markers="markers" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="london" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Marker with label example</h1>
   </body>
 </html>

--- a/examples/0506-markers-groups-example.html
+++ b/examples/0506-markers-groups-example.html
@@ -110,7 +110,7 @@
     </style>
 </head>
 <body ng-controller="MarkersGroupController">
-    <leaflet center="london" markers="markers" layers="layers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="london" markers="markers" layers="layers" height="480px" width="100%"></leaflet>
     <h1>This is a map with two hidden marker groups</h1>
     <p>Click here to hide or show the groups:</p>
     <button type="button" ng-click="toggleLayer('red')" class="btn btn-default">Red</button>

--- a/examples/0506-markers-rotation-example.html
+++ b/examples/0506-markers-rotation-example.html
@@ -53,7 +53,7 @@
     </script>
   </head>
   <body ng-controller="MarkersRotationController">
-      <leaflet center="chicago" markers="markers" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="chicago" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Changing Icon Rotation</h1>
     </div>
   </body>

--- a/examples/0507-markers-change-opacity-example.html
+++ b/examples/0507-markers-change-opacity-example.html
@@ -29,7 +29,7 @@
     </script>
   </head>
   <body ng-controller="MarkersChangeOpacityController   ">
-    <leaflet center="chicago" markers="markers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="chicago" markers="markers" height="480px" width="100%"></leaflet>
     <h1>Change icon opacity</h1>
     <p>Move the slider to change the icon opacity.</p>
     <input type="range" min="0" max="1" step="0.01" ng-model="markers.m1.opacity" />

--- a/examples/0508-markers-clustering-example.html
+++ b/examples/0508-markers-clustering-example.html
@@ -105,7 +105,7 @@
     </style>
 </head>
 <body ng-controller="MarkersClusteringController">
-    <leaflet center="center" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" markers="markers" layers="layers" width="100%" height="480px"></leaflet>
     <h1>Marker clustering example</h1>
     <p>You can create a marker-clustering group on the map, defining <strong>layers</strong> and your <strong>markers</strong> definition as this example.</p>
 </body>

--- a/examples/0509-markers-clustering-without-overlays-example.html
+++ b/examples/0509-markers-clustering-without-overlays-example.html
@@ -78,7 +78,7 @@
     </script>
 </head>
 <body ng-controller="MarkersClusteringWithoutOverlaysController">
-    <leaflet center="london" markers="markers" height="480px" width="100%"></leaflet>
+    <leaflet lf-center="london" markers="markers" height="480px" width="100%"></leaflet>
     <h1>Marker clustering example without layers</h1>
 </body>
 </html>

--- a/examples/0510-markers-modal-markercluster-example.html
+++ b/examples/0510-markers-modal-markercluster-example.html
@@ -101,7 +101,7 @@
         <i class="close icon"></i>
         <div class="header">Modal map example</div>
         <div class="content">
-            <leaflet defaults="defaults" layers="layers" center="center" markers="markers" width="100%" height="320px"></leaflet>
+            <leaflet defaults="defaults" layers="layers" lf-center="center" markers="markers" width="100%" height="320px"></leaflet>
         </div>
         <div class="actions">
             <div class="ui button">Cancel</div>

--- a/examples/0511-markers-clustering-10000-markers-example.html
+++ b/examples/0511-markers-clustering-10000-markers-example.html
@@ -64,7 +64,7 @@
     </script>
 </head>
 <body ng-controller="MarkersClustering10000MarkersController">
-    <leaflet center="center" markers="markers" layers="layers" event-broadcast="events" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" markers="markers" layers="layers" event-broadcast="events" width="100%" height="480px"></leaflet>
     <h1>Marker clustering example (10000 markers)</h1>
 </body>
 </html>

--- a/examples/0512-markers-events-example.html
+++ b/examples/0512-markers-events-example.html
@@ -44,7 +44,7 @@
     </script>
   </head>
   <body ng-controller="MarkersEventsController">
-    <leaflet event-broadcast="events" center="center" markers="markers" width="100%" height="400px"></leaflet>
+    <leaflet event-broadcast="events" lf-center="center" markers="markers" width="100%" height="400px"></leaflet>
     <h1>Marker Events example</h1>
     <ul>
         <li><strong ng-bind="eventDetected"></strong> event caught in listener.</li>

--- a/examples/0513-markers-delayed-events.html
+++ b/examples/0513-markers-delayed-events.html
@@ -61,7 +61,7 @@
     </script>
   </head>
   <body ng-controller="MarkersDelayedEventsController">
-      <leaflet events-broadcast="events" center="london" markers="markers" height="480px" width="100%"></leaflet>
+      <leaflet events-broadcast="events" lf-center="london" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Markers delayed events example</h1>
       <button ng-click="removeMarkers()">Remove markers</button>
       <button ng-click="addMarkers()">Add markers</button>

--- a/examples/0514-markers-angular-template-example.html
+++ b/examples/0514-markers-angular-template-example.html
@@ -67,7 +67,7 @@
     </script>
   </head>
   <body ng-controller="MarkersAngularTemplateController">
-      <leaflet center="london" markers="data.markers" height="480px" width="100%"></leaflet>
+      <leaflet lf-center="london" markers="data.markers" height="480px" width="100%"></leaflet>
       <h1>Markers angular template example</h1>
       <button ng-click="removeMarkers()">Remove markers</button>
       <button ng-click="addMarkers()">Add markers</button>

--- a/examples/0515-markers-two-maps-events-example.html
+++ b/examples/0515-markers-two-maps-events-example.html
@@ -114,8 +114,8 @@
     </script>
   </head>
   <body ng-controller="MarkersTwoMapsEventsController">
-      <leaflet defaults="defaults" event-broadcast="events" center="center" markers="markers" layers="layers" id="global-map" width="100%" height="240px"></leaflet>
-      <leaflet defaults="defaults2" event-broadcast="events2" center="center2" markers="markers2" layers="layers2" id="global-map2" width="100%" height="240px"></leaflet>
+      <leaflet defaults="defaults" event-broadcast="events" lf-center="center" markers="markers" layers="layers" id="global-map" width="100%" height="240px"></leaflet>
+      <leaflet defaults="defaults2" event-broadcast="events2" lf-center="center2" markers="markers2" layers="layers2" id="global-map2" width="100%" height="240px"></leaflet>
       <h1>Two maps with markers and events</h1>
       <p>Click on any of the markers to show a popup with a message.</p>
   </body>

--- a/examples/0600-mixed-image-legend-example.html
+++ b/examples/0600-mixed-image-legend-example.html
@@ -92,7 +92,7 @@
 <body ng-controller="ImageLegendServiceController">
     <h1>Image Legend Service</h1>
     <p>Use the button to switch another Layer with different legend.</p>
-    <leaflet center="usa" layers="layers" markers="markers" height="480px" width="100%"
+    <leaflet lf-center="usa" layers="layers" markers="markers" height="480px" width="100%"
     	legend="legend" defaults="options"></leaflet>
     <br/>
     <button ng-click="switchLegend()">Switch Legend</button>

--- a/examples/0601-mixed-geojson-events-example.html
+++ b/examples/0601-mixed-geojson-events-example.html
@@ -179,7 +179,7 @@
     </style>
   </head>
   <body ng-controller="MixedGeoJSONEventsController">
-      <leaflet center="center" events="events" legend="legend" geojson="geojson"></leaflet>
+      <leaflet lf-center="center" events="events" legend="legend" geojson="geojson"></leaflet>
       <div class="worldmap country f32">
         <div ng-show="selectedCountry" class="flag" ng-class="countries[selectedCountry.id]['alpha-2']|lowercase"></div>
         {{ selectedCountry.properties.name || 'No country'}}

--- a/examples/0602-mixed-mapbox-tiles-geojson-example.html
+++ b/examples/0602-mixed-mapbox-tiles-geojson-example.html
@@ -37,7 +37,7 @@
     </script>
 </head>
 <body ng-controller="MixedMapboxTilesGeojsonController">
-    <leaflet center="center" tiles="tiles" geojson="geojson" width="100%" height="480px"></leaflet>
+    <leaflet lf-center="center" tiles="tiles" geojson="geojson" width="100%" height="480px"></leaflet>
     <h1>Mapbox tiles and Mapbox GeoJSON loading</h1>
     <pre ng-bind="layers | json"></pre>
 </body>

--- a/examples/0603-mixed-layers-overlays-geojson-example.html
+++ b/examples/0603-mixed-layers-overlays-geojson-example.html
@@ -1,82 +1,82 @@
 <!DOCTYPE html>
 <html ng-app="demoapp">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<script src="../bower_components/angular/angular.min.js"></script>
-	<script src="../bower_components/leaflet/dist/leaflet.js"></script><script src="../bower_components/angular-simple-logger/dist/index.js"></script>
-	<script src="../bower_components/leaflet-tilelayer-geojson/TileLayer.GeoJSON.js"></script>
-	<link rel="stylesheet" href="../bower_components/leaflet/dist/leaflet.css" />
-	<script src="../dist/angular-leaflet-directive.js"></script>
-	<script>
-		var app = angular.module('demoapp', ["leaflet-directive"]);
-		app.controller("MixedLayersOverlaysGeoJSONController", ["$scope", function($scope){
-				angular.extend($scope, {
-			        sanfrancisco: {
-			            lat: 37.79,
-			            lng: -122.4,
-			            zoom: 17
-		       		},
-					defaults: {
-			            scrollWheelZoom: false
-			        },
-			        layers:{
-			        	baselayers: {
-						osm:{
-				        		name: "OpenStreetMap (XYZ)",
-				        		type: "xyz",
-								url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-		                        layerOptions: {
-		                            subdomains: ['a', 'b', 'c'],
-		                            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-		                            continuousWorld: true
-		                        }
-		        			}
-			        	}
-		        	,
-		        	overlays: {
-		                buildings: {
-		                	name:'Buildings',
-		                	type: 'geoJSON',
-		                	url:'http://tile.openstreetmap.us/vectiles-buildings/{z}/{x}/{y}.json',
-		                	layerOptions: {
-		                        	style: {
-								        "color": "#00D",
-								        "fillColor": "#00D",
-								        "weight": 1.0,
-								        "opacity": 0.6,
-								        "fillOpacity": .2
-								    }
-		                        },
-	                        pluginOptions:{
-	                        	cliptiles: true
-	                        }
-		                },
-		                Roads:{
-		                	name:'Roads',
-		                	type: 'geoJSON',
-		                	url: 'http://tile.openstreetmap.us/vectiles-skeletron/{z}/{x}/{y}.json',
-		                	layerOptions: {
-		                        	style: {
-								        "color": "#DD0000 ",
-								        "fillColor": "#DD0000",
-								        "weight": 1.0,
-								        "fillOpacity": .4
-								    }
-		                        },
-	                        pluginOptions:{
-	                        	cliptiles: false
-	                        }
-		                }
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="../bower_components/angular/angular.min.js"></script>
+  <script src="../bower_components/leaflet/dist/leaflet.js"></script><script src="../bower_components/angular-simple-logger/dist/index.js"></script>
+  <script src="../bower_components/leaflet-tilelayer-geojson/TileLayer.GeoJSON.js"></script>
+  <link rel="stylesheet" href="../bower_components/leaflet/dist/leaflet.css" />
+  <script src="../dist/angular-leaflet-directive.js"></script>
+  <script>
+    var app = angular.module('demoapp', ["leaflet-directive"]);
+    app.controller("MixedLayersOverlaysGeoJSONController", ["$scope", function($scope){
+        angular.extend($scope, {
+              sanfrancisco: {
+                  lat: 37.79,
+                  lng: -122.4,
+                  zoom: 17
+              },
+          defaults: {
+                  scrollWheelZoom: false
+              },
+              layers:{
+                baselayers: {
+            osm:{
+                    name: "OpenStreetMap (XYZ)",
+                    type: "xyz",
+                url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+                            layerOptions: {
+                                subdomains: ['a', 'b', 'c'],
+                                attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+                                continuousWorld: true
+                            }
+                  }
+                }
+              ,
+              overlays: {
+                    buildings: {
+                      name:'Buildings',
+                      type: 'geoJSON',
+                      url:'http://tile.openstreetmap.us/vectiles-buildings/{z}/{x}/{y}.json',
+                      layerOptions: {
+                              style: {
+                        "color": "#00D",
+                        "fillColor": "#00D",
+                        "weight": 1.0,
+                        "opacity": 0.6,
+                        "fillOpacity": .2
+                    }
+                            },
+                          pluginOptions:{
+                            cliptiles: true
+                          }
+                    },
+                    Roads:{
+                      name:'Roads',
+                      type: 'geoJSON',
+                      url: 'http://tile.openstreetmap.us/vectiles-skeletron/{z}/{x}/{y}.json',
+                      layerOptions: {
+                              style: {
+                        "color": "#DD0000 ",
+                        "fillColor": "#DD0000",
+                        "weight": 1.0,
+                        "fillOpacity": .4
+                    }
+                            },
+                          pluginOptions:{
+                            cliptiles: false
+                          }
+                    }
 
-		        		}
-			        }
-		    	})
-		   	}]);
-	</script>
+                }
+              }
+          })
+        }]);
+  </script>
 </head>
 <body ng-controller='MixedLayersOverlaysGeoJSONController'>
-		<leaflet height="480px" width="100%" center="sanfrancisco" layers="layers"></leaflet>
-		<h1> GeoJSON TileLayers</h1>
-		<p>Data source: Openstreetmap (buildings data) </p>
+    <leaflet height="480px" width="100%" lf-center="sanfrancisco" layers="layers"></leaflet>
+    <h1> GeoJSON TileLayers</h1>
+    <p>Data source: Openstreetmap (buildings data) </p>
 </body>
 </html>

--- a/examples/0604-mixed-markers-nested-events-example.html
+++ b/examples/0604-mixed-markers-nested-events-example.html
@@ -76,7 +76,7 @@
   <leaflet
       ng-if="map.show"
       event-broadcast="events"
-      center="center"
+      lf-center="center"
       markers="markers"
       markers-nested="true"
       layers="layers"

--- a/examples/0605-mixed-overlays-markers-nested-no-watch-example.html
+++ b/examples/0605-mixed-overlays-markers-nested-no-watch-example.html
@@ -155,7 +155,7 @@
 </head>
 <body ng-controller="MixedMOverlaysMarkersNestedNoWatchController">
     <leaflet
-        center="center"
+        lf-center="center"
         markers="markers"
         layers="layers"
         markers-nested="true"

--- a/examples/805-markers-updates.html
+++ b/examples/805-markers-updates.html
@@ -143,10 +143,10 @@
 
 <body >
     <div ng-controller="Ctrl">
-        <leaflet id="map1" width="100%" height="480px" center="center" markers="markers" markers-nested="true" layers="layers"></leaflet>
+        <leaflet id="map1" width="100%" height="480px" lf-center="center" markers="markers" markers-nested="true" layers="layers"></leaflet>
     </div>
     <div ng-controller="Ctrl2">
-        <leaflet id="map2" width="100%" height="480px" center="center" markers="markers" layers="layers"></leaflet>
+        <leaflet id="map2" width="100%" height="480px" lf-center="center" markers="markers" layers="layers"></leaflet>
     </div>
 
 </body>

--- a/test/unit/boundsDirectiveSpec.js
+++ b/test/unit/boundsDirectiveSpec.js
@@ -37,7 +37,7 @@ describe('Directive: bounds', function() {
             bounds: bounds,
             center: {}
         });
-        var element = angular.element('<leaflet bounds="bounds" center="center"></leaflet>');
+        var element = angular.element('<leaflet bounds="bounds" lf-center="center"></leaflet>');
         element = $compile(element)(scope);
 
         var map;
@@ -58,7 +58,7 @@ describe('Directive: bounds', function() {
             bounds: {},
             center: {}
         });
-        var element = angular.element('<leaflet bounds="bounds" center="center"></leaflet>');
+        var element = angular.element('<leaflet bounds="bounds" lf-center="center"></leaflet>');
         element = $compile(element)(scope);
 
         var map;
@@ -78,7 +78,7 @@ describe('Directive: bounds', function() {
             bounds: {},
             center: { lat: 5 , lng: -3, zoom: 4 }
         });
-        var element = angular.element('<leaflet bounds="bounds" center="center"></leaflet>');
+        var element = angular.element('<leaflet bounds="bounds" lf-center="center"></leaflet>');
         element = $compile(element)(scope);
 
         var map;
@@ -104,7 +104,7 @@ describe('Directive: bounds', function() {
             bounds: bounds,
             center: {}
         });
-        var element = angular.element('<leaflet bounds="bounds" center="center"></leaflet>');
+        var element = angular.element('<leaflet bounds="bounds" lf-center="center"></leaflet>');
         element = $compile(element)(scope);
 
         var map;
@@ -133,7 +133,7 @@ describe('Directive: bounds', function() {
             bounds: bounds,
             center: {}
         });
-        var element = angular.element('<leaflet bounds="bounds" center="center"></leaflet>');
+        var element = angular.element('<leaflet bounds="bounds" lf-center="center"></leaflet>');
         element = $compile(element)(scope);
 
         var map;


### PR DESCRIPTION
Since the center directive will be deprecated the use of lf-center should be encouraged.