### PR TITLE
Add support for Leaflet plugin 'Leaflet.vector-markers'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "leaflet-tilelayer-geojson": "*",
     "Leaflet.utfgrid": "danzel/Leaflet.utfgrid",
     "Leaflet.awesome-markers": "*",
-    "Leaflet.vector-markers": "leaflet.vector-markers#0.0.3",
+    "leaflet.vector-markers": "~0.0.3",
     "webgl-heatmap-leaflet": "*",
     "leaflet-plugins": "*",
     "esri-leaflet": "*",

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "dist/angular-leaflet-directive.js"
   ],
   "dependencies": {
-    "Leaflet.vector-markers": "https://github.com/hiasinho/Leaflet.vector-markers",
     "angular": "1.x",
     "angular-simple-logger": "~0.0.1",
     "leaflet": "0.7.x"
@@ -33,7 +32,7 @@
     "leaflet-tilelayer-geojson": "*",
     "Leaflet.utfgrid": "danzel/Leaflet.utfgrid",
     "Leaflet.awesome-markers": "*",
-    "Leaflet.vector-markers": "hiasinho/Leaflet.vector-markers",
+    "Leaflet.vector-markers": "leaflet.vector-markers#0.0.3",
     "webgl-heatmap-leaflet": "*",
     "leaflet-plugins": "*",
     "esri-leaflet": "*",

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "dist/angular-leaflet-directive.js"
   ],
   "dependencies": {
+    "Leaflet.vector-markers": "https://github.com/hiasinho/Leaflet.vector-markers",
     "angular": "1.x",
     "angular-simple-logger": "~0.0.1",
     "leaflet": "0.7.x"
@@ -32,6 +33,7 @@
     "leaflet-tilelayer-geojson": "*",
     "Leaflet.utfgrid": "danzel/Leaflet.utfgrid",
     "Leaflet.awesome-markers": "*",
+    "Leaflet.vector-markers": "hiasinho/Leaflet.vector-markers",
     "webgl-heatmap-leaflet": "*",
     "leaflet-plugins": "*",
     "esri-leaflet": "*",

--- a/examples/0503-markers-icons-example.html
+++ b/examples/0503-markers-icons-example.html
@@ -6,6 +6,7 @@
     <script src="../bower_components/leaflet/dist/leaflet.js"></script>
     <script src="../bower_components/angular-simple-logger/dist/index.js"></script>
     <script src="../bower_components/Leaflet.awesome-markers/dist/leaflet.awesome-markers.js"></script>
+    <script src="../bower_components/Leaflet.vector-markers/dist/Leaflet.vector-markers.js"></script>
     <script src="../bower_components/Leaflet.MakiMarkers/Leaflet.MakiMarkers.js"></script>
     <script src="../bower_components/Leaflet.ExtraMarkers/src/leaflet.extra-markers.js"></script>
     <script src="../dist/angular-leaflet-directive.min.js"></script>
@@ -14,6 +15,7 @@
     <link rel="stylesheet" href="../bower_components/leaflet/dist/leaflet.css" />
     <link rel="stylesheet" href="../bower_components/font-awesome/css/font-awesome.min.css">
     <link rel="stylesheet" href="../bower_components/Leaflet.awesome-markers/dist/leaflet.awesome-markers.css">
+    <link rel="stylesheet" href="../bower_components/Leaflet.vector-markers/dist/Leaflet.vector-markers.css">
     <link rel="stylesheet" href="../bower_components/Leaflet.ExtraMarkers/src/leaflet.extra-markers.css">
 
     <script>
@@ -64,6 +66,11 @@
                     icon: 'tag',
                     markerColor: 'red'
                 },
+                vectorMarkerIcon: {
+                    type: 'vectorMarker',
+                    icon: 'tag',
+                    markerColor: 'red'
+                },
                 makiMarkerIcon: {
                     type: 'makiMarker',
                     icon: 'beer',
@@ -89,7 +96,7 @@
   <body ng-controller="MarkersIconsController">
       <leaflet lf-center="chicago" markers="markers" height="480px" width="100%"></leaflet>
       <h1>Changing the marker icons</h1>
-      <p>You can change the marker icons, using the default Leaflet marker icons functions, or using helper libraries like AwesomeMarkers, MakiMarkers or ExtraMarker.</p>
+      <p>You can change the marker icons, using the default Leaflet marker icons functions, or using helper libraries like AwesomeMarkers, VectorMarkers, MakiMarkers or ExtraMarker.</p>
 
       <h2>Default Icons</h2>
       <button ng-click="markers.m1.icon=defaultIcon">Default</button>
@@ -110,6 +117,22 @@
           <button ng-click="markers.m1.icon=awesomeMarkerIcon; markers.m1.icon.icon='cog'">Cog</button>
           <button ng-click="markers.m1.icon=awesomeMarkerIcon; markers.m1.icon.icon='star'">Star</button>
           <button ng-click="markers.m1.icon=awesomeMarkerIcon; markers.m1.icon.icon='certificate'">Certificate</button>
+      </p>
+
+      <h2>VectorMarker Icons</h2>
+      <p>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.markerColor='blue'">Blue</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.markerColor='red'">Red</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.markerColor='green'">Green</button>
+      </p>
+      <p>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='tag'">Tag</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='usd'">USD</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='heart'">Heart</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='home'">Home</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='cog'">Cog</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='star'">Star</button>
+          <button ng-click="markers.m1.icon=vectorMarkerIcon; markers.m1.icon.icon='certificate'">Certificate</button>
       </p>
 
       <h2>MakiMarker Icons</h2>

--- a/src/services/leafletHelpers.js
+++ b/src/services/leafletHelpers.js
@@ -269,6 +269,29 @@ angular.module("leaflet-directive").service('leafletHelpers', function ($q, $log
             }
         },
 
+        VectorMarkersPlugin: {
+            isLoaded: function() {
+                return angular.isDefined(L.VectorMarkers) && angular.isDefined(L.VectorMarkers.Icon);
+            },
+            is: function(icon) {
+                if (this.isLoaded()) {
+                    return icon instanceof L.VectorMarkers.Icon;
+                } else {
+                    return false;
+                }
+            },
+            equal: function (iconA, iconB) {
+                if (!this.isLoaded()) {
+                    return false;
+                }
+                if (this.is(iconA)) {
+                    return angular.equals(iconA, iconB);
+                } else {
+                    return false;
+                }
+            }
+        },
+
         DomMarkersPlugin: {
             isLoaded: function () {
                 if (angular.isDefined(L.DomMarkers) && angular.isDefined(L.DomMarkers.Icon)) {

--- a/src/services/leafletLayerHelpers.js
+++ b/src/services/leafletLayerHelpers.js
@@ -81,6 +81,16 @@ angular.module("leaflet-directive")
                 });
             }
         },
+        geoJSONVectorMarker: {
+            mustHaveUrl: false,
+            createLayer: function(params) {
+                    return new L.geoJson(params.data, {
+                        pointToLayer: function (feature, latlng) {
+                            return L.marker(latlng, {icon: L.VectorMarkers.icon(params.icon)});
+                    }
+                });
+            }
+        },
         utfGrid: {
             mustHaveUrl: true,
             createLayer: utfGridCreateLayer

--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -3,6 +3,7 @@ angular.module("leaflet-directive").service('leafletMarkersHelpers', function ($
         defaultTo = leafletHelpers.defaultTo,
         MarkerClusterPlugin = leafletHelpers.MarkerClusterPlugin,
         AwesomeMarkersPlugin = leafletHelpers.AwesomeMarkersPlugin,
+        VectorMarkersPlugin = leafletHelpers.VectorMarkersPlugin,
         MakiMarkersPlugin = leafletHelpers.MakiMarkersPlugin,
         ExtraMarkersPlugin = leafletHelpers.ExtraMarkersPlugin,
         DomMarkersPlugin = leafletHelpers.DomMarkersPlugin,
@@ -37,6 +38,14 @@ angular.module("leaflet-directive").service('leafletMarkersHelpers', function ($
             }
 
             return new L.AwesomeMarkers.icon(iconData);
+        }
+
+        if (isDefined(iconData) && isDefined(iconData.type) && iconData.type === 'vectorMarker') {
+            if (!VectorMarkersPlugin.isLoaded()) {
+                $log.error(errorHeader + ' The VectorMarkers Plugin is not loaded.');
+            }
+
+            return new L.VectorMarkers.icon(iconData);
         }
 
         if (isDefined(iconData) && isDefined(iconData.type) && iconData.type === 'makiMarker') {

--- a/test/karma-unit.conf.js
+++ b/test/karma-unit.conf.js
@@ -22,6 +22,7 @@ module.exports = function(karma) {
             'bower_components/angular-mocks/angular-mocks.js',
             'bower_components/angular-simple-logger/dist/index.js',
             'bower_components/leaflet.markercluster/dist/leaflet.markercluster.js',
+            'bower_components/leaflet.vector-markers/dist/Leaflet.vector-markers.js',
             'dist/angular-leaflet-directive_dev_mapped.js',
             'test/unit/bootstrap.coffee',
             'test/unit/*.js',

--- a/test/unit/plugin/markerPluginVectorMarkersSpec.js
+++ b/test/unit/plugin/markerPluginVectorMarkersSpec.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/*jshint -W117 */
+/*jshint globalstrict: true*/
+/* jasmine specs for directives go here */
+
+describe('Plugin: VectorMarkers', function() {
+    var $compile, $rootScope, scope, leafletData, leafletHelpers;
+
+    beforeEach(module('leaflet-directive'));
+    beforeEach(inject(function(_$compile_, _$rootScope_, _leafletData_, _leafletHelpers_){
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        scope = $rootScope.$new();
+        leafletData = _leafletData_;
+        leafletHelpers = _leafletHelpers_;
+    }));
+
+    afterEach(inject(function($rootScope) {
+        $rootScope.$apply();
+    }));
+
+    it('should load plugin for the vector markers', function(){
+        var plugin = leafletHelpers.VectorMarkersPlugin;
+
+        expect(plugin).toBeDefined();
+        expect(plugin.isLoaded()).toBeTruthy();
+    });
+
+    it('should create a new vector marker', function() {
+        var myMarker = {
+            lat: 51,
+            lng: 0,
+            icon: {
+                type: 'vectorMarker',
+                icon: 'tag',
+                markerColor: 'red'
+            }
+        };
+
+        angular.extend(scope, {
+            markers : {
+                myMarker: myMarker
+            }
+        });
+
+        var element = angular.element('<leaflet markers="markers"></leaflet>');
+        element = $compile(element)(scope);
+        scope.$digest();
+
+        var plugin = leafletHelpers.VectorMarkersPlugin;
+
+        leafletData.getMarkers().then(function(markers) {
+            expect(markers).toBeDefined();
+            expect(markers.myMarker).toBeDefined();
+            expect(plugin.is(markers.myMarker.options.icon)).toBeTruthy();
+        });
+    });
+
+    it('icon should differ from a common marker\'s icon', function() {
+        var commonMarker = {
+          lat: 51,
+          lng: 0,
+          icon: {}
+        };
+        var vectorMarker = {
+            lat: 51,
+            lng: 0,
+            icon: {
+                type: 'vectorMarker',
+                icon: 'tag',
+                markerColor: 'red'
+            }
+        };
+
+        angular.extend(scope, {
+            markers : {
+                commonMarker: commonMarker,
+                vectorMarker: vectorMarker
+            }
+        });
+
+        var element = angular.element('<leaflet markers="markers"></leaflet>');
+        element = $compile(element)(scope);
+        scope.$digest();
+
+        var plugin = leafletHelpers.VectorMarkersPlugin;
+
+        leafletData.getMarkers().then(function(markers) {
+            expect(markers).toBeDefined();
+            expect(markers.commonMarker).toBeDefined();
+            expect(markers.vectorMarker).toBeDefined();
+            expect(plugin.is(markers.commonMarker.options.icon)).toBeFalsy();
+            expect(plugin.is(markers.vectorMarker.options.icon)).toBeTruthy();
+            expect(plugin.equal(markers.commonMarker.options.icon, markers.vectorMarker.options.icon)).toBeFalsy();
+        });
+    });
+
+});


### PR DESCRIPTION
- Leaflet.vector-markers is a fork of Leaflet.awesome-markers, but instead
  of PNGs it uses SVGs as markers.
- Add additional example to the already existing marker examples.