### PR TITLE
Remove deprecated version key from Bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "angular-leaflet-directive",
   "author": "https://github.com/tombatossals/angular-leaflet-directive/graphs/contributors",
   "description": "angular-leaflet-directive - An AngularJS directive to easily interact with Leaflet maps",
-  "version": "0.8.8",
   "homepage": "http://tombatossals.github.io/angular-leaflet-directive/",
   "keywords": [
     "angularjs",


### PR DESCRIPTION
http://bower.io/docs/creating-packages/#version

>Deprecated. Use git or svn tags instead. This field is ignored by Bower.