### PR TITLE
Removed extra comma from the return object

### DIFF
--- a/src/services/leafletLegendHelpers.js
+++ b/src/services/leafletLegendHelpers.js
@@ -58,6 +58,6 @@ angular.module("leaflet-directive").factory('leafletLegendHelpers', function () 
 	return {
 		getOnAddLegend: _getOnAddLegend,
 		getOnAddArrayLegend: _getOnAddArrayLegend,
-		updateLegend: _updateLegend,
+		updateLegend: _updateLegend
 	};
 });


### PR DESCRIPTION
**Problem**
The extra comma at the end of this line is causing an issue in Internet Explorer 10. The original error was

```
Expected identifier, string or number
```

In our case, this was causing our Angular.js application to crash.

This is due to an incomplete implementation of ECMA5 in Internet Explorer 10. See ECMA 5 specification here http://ecma262-5.com/ELS5_HTML.htm#Section_11.1.5 

**Solution**
To solve this problem, we removed the extra comma.