### PR TITLE
add support for passing a center offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Bug fixes and new features
+- Added support for center offset.
+- Fixed edition of path that wasn't updating labels and popups.
+- Fixed edition of markers that was hiding the popup that was visible.
+
 # angular-leaflet-directive
 ## [tombatossals](http://github.com/tombatossals/angular-leaflet-directive) - main upstream
 [![Join the chat at https://gitter.im/tombatossals/angular-leaflet-directive](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tombatossals/angular-leaflet-directive?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/src/directives/center.js
+++ b/src/directives/center.js
@@ -155,6 +155,24 @@ centerDirectiveTypes.forEach(function(directiveName) {
 
                         //$log.debug("updating map center...", center);
                         leafletScope.settingCenterFromScope = true;
+
+                    	//adding support for center offset, it can be a number or an array of two values where if it's a number
+                    	//it's the offset from the left and if it's an array the first position is the offset from the left and
+    					//the second one is from the top, if negative values are provided the orientation is reversed
+                        var centerPoint = [center.lat, center.lng];
+                        if (center.offset) {
+                        	var targetPoint;
+    						if (angular.isNumber(center.offset)) {
+    							targetPoint = map.project(centerPoint, center.zoom).subtract([center.offset / 2, 0]);
+    							centerPoint = map.unproject(targetPoint, center.zoom);
+    						} else if (angular.isArray(center.offset)) {
+    							targetPoint = map.project(centerPoint, center.zoom).subtract([center.offset[0] / 2, center.offset[1] / 2]);
+    							centerPoint = map.unproject(targetPoint, center.zoom);
+    						} else {
+    							$log.warn(errorHeader + " invalid 'center offset'");
+    						}
+                        }
+                        
                         map.setView([center.lat, center.lng], center.zoom);
                         leafletEvents.notifyCenterChangedToBounds(leafletScope, map);
                         $timeout(function() {

--- a/src/directives/paths.js
+++ b/src/directives/paths.js
@@ -58,6 +58,15 @@ angular.module("leaflet-directive").directive('paths', function (leafletLogger, 
                                 return;
                             }
                             setPathOptions(leafletPath, pathData.type, pathData);
+                        	// Show label if defined
+                            if (isDefined(leafletPath) && leafletHelpers.LabelPlugin.isLoaded() && isDefined(pathData.label) && isDefined(pathData.label.message)) {
+                            	leafletPath.bindLabel(pathData.label.message, pathData.label.options);
+                            }
+
+                        	// bind popup if defined
+                            if (isDefined(leafletPath) && isDefined(pathData.message)) {
+                            	leafletPath.bindPopup(pathData.message, pathData.popupOptions);
+                            }
                         }, true);
                     };
 

--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -358,19 +358,12 @@ angular.module("leaflet-directive").service('leafletMarkersHelpers', function ($
                 marker.setPopupContent(markerData.message);
             }
 
-            // Update the focus property
-            var updatedFocus = false;
-            if (markerData.focus !== true && oldMarkerData.focus === true) {
-                // If there was a focus property and was true we turn it off
-                marker.closePopup();
-                updatedFocus = true;
-            }
-
-            // The markerData.focus property must be true so we update if there wasn't a previous value or it wasn't true
-            if (markerData.focus === true && ( !isDefined(oldMarkerData.focus) || oldMarkerData.focus === false) || (isInitializing && markerData.focus === true)) {
-                // Reopen the popup when focus is still true
-                marker.openPopup();
-                updatedFocus = true;
+            markerData.focus = oldMarkerData.focus;
+            if (markerData.focus) {
+            	marker.openPopup();
+                _manageOpenPopup(marker, markerData, map);
+            } else {
+            	marker.closePopup();
             }
 
             // zIndexOffset adjustment


### PR DESCRIPTION
the center now could be and object like:
{lat: 32, lng: -96, zoom: 4, offset: [400, 0]}

the offset property can be a number or an array of two values where if it's a number it's the offset from the left and if it's an array the first position is the offset from the left and the second one is from the top, if negative values are provided the orientation is reversed, the values for the offset are in pixels and if not offset property is passed then it's ignored