### PR TITLE
chore(grunt) getAvailPort not Windows-friendly

### DIFF
--- a/grunt/utils/getAvailPort.js
+++ b/grunt/utils/getAvailPort.js
@@ -1,7 +1,14 @@
 var exec =  require('shelljs').exec;
 
+var isWin = /^win/.test(process.platform);
+
 var isPortOpen =  function(port){
-  var portResponse = exec('lsof -i:' + port + " | tail -n 1 | awk '{print $2}'", {silent:true}).output;
+  var cmd;
+  if(isWin)
+  	cmd = 'netstat -an | find /i ":' + port + '" | find /i "listening"';
+  else
+  	cmd = 'lsof -i:' + port + " | tail -n 1 | awk '{print $2}'";
+  var portResponse = exec(cmd, {silent:true}).output;
   return portResponse? false: true;
 }
 


### PR DESCRIPTION
Now checks if platform is Windows, and if so, uses `netstat` instead of
`lsof`.

Fixes #977