### PR TITLE
Changed marker icon - reopen popup if marker has been already focused

### DIFF
--- a/src/services/leafletMarkersHelpers.js
+++ b/src/services/leafletMarkersHelpers.js
@@ -329,6 +329,10 @@ angular.module("leaflet-directive").service('leafletMarkersHelpers', function ($
                 marker.unbindPopup();
                 if (isString(markerData.message)) {
                     marker.bindPopup(markerData.message, markerData.popupOptions);
+                    // if marker has been already focused, reopen popup
+                    if (map.hasLayer(marker) && markerData.focus === true) {
+                        marker.openPopup();
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR describes following use case:

update marker's icon and still be able to see open popup (with the updated popup message as well). Marker represents object with changing lat lngs, icon is a pointer representing object's current direction through css3 transform.

We can discuss the need of this PR, but this is basically what i had to use in production.

