### PR TITLE
bump version to 0.10.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-leaflet-directive",
   "author": "https://github.com/tombatossals/angular-leaflet-directive/graphs/contributors",
   "description": "angular-leaflet-directive - An AngularJS directive to easily interact with Leaflet maps",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "http://tombatossals.github.io/angular-leaflet-directive/",
   "keywords": [
     "angularjs",


### PR DESCRIPTION
bower.json in the repo root only has 0.9 specified. This bumps to 0.10.0 to match the current relase