### PR TITLE
fix karma: Fix Leaflet vector markers file name

### DIFF
--- a/test/karma-unit.conf.js
+++ b/test/karma-unit.conf.js
@@ -9,7 +9,7 @@ module.exports = function(karma) {
         'bower_components/angular/angular.js',
         'bower_components/angular-mocks/angular-mocks.js',
         'bower_components/leaflet.markercluster/dist/leaflet.markercluster.js',
-        'bower_components/leaflet.vector-markers/dist/Leaflet.vector-markers.js',
+        'bower_components/[Ll]eaflet.vector-markers/dist/[Ll]eaflet[\.-]vector-markers.js',
         'bower_components/Leaflet.PolylineDecorator/leaflet.polylineDecorator.js',
         'dist/angular-leaflet-directive.js',
         'test/unit/*.js',


### PR DESCRIPTION
`Leaflet.vector-markers` has changed the filename for the dist/
JavaScript files in 0.0.5

https://github.com/hiasinho/Leaflet.vector-markers/tree/0.0.4/dist
https://github.com/hiasinho/Leaflet.vector-markers/tree/0.0.5/dist

This causes the plugin tests to fail as the file cannot be found

Use a regex to support 0.0.5 and remain backwards compatible with 0.0.4
