### PR TITLE
specify protocol during call to openstreetmap

### DIFF
--- a/dist/angular-leaflet-directive.js
+++ b/dist/angular-leaflet-directive.js
@@ -2228,7 +2228,7 @@ angular.module('leaflet-directive').factory('leafletMapDefaults', ["$q", "leafle
         server: ' http://nominatim.openstreetmap.org/search',
       },
       crs: L.CRS.EPSG3857,
-      tileLayer: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      tileLayer: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       tileLayerOptions: {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       },


### PR DESCRIPTION
I was having trouble using the Leaflet directive because it was using file:// over http://, yielding many errors similar to:

GET file://c.tile.openstreetmap.org/17/38591/49266.png net::ERR_FILE_NOT_FOUND
