### PR TITLE
(fix) isSameCenterOnMap returns false if coords are nil

### DIFF
--- a/src/services/leafletHelpers.js
+++ b/src/services/leafletHelpers.js
@@ -198,7 +198,8 @@ angular.module('leaflet-directive').service('leafletHelpers', function($q, $log)
     isSameCenterOnMap: function(centerModel, map) {
       var mapCenter = map.getCenter();
       var zoom = map.getZoom();
-      if (centerModel.lat && centerModel.lng &&
+      if (typeof centerModel.lat === 'number' &&
+          typeof centerModel.lng === 'number' &&
           mapCenter.lat.toFixed(4) === centerModel.lat.toFixed(4) &&
           mapCenter.lng.toFixed(4) === centerModel.lng.toFixed(4) &&
           zoom === centerModel.zoom) {


### PR DESCRIPTION
`isSameCenterOnMap` helper function returns true when mapCenter and centerModel's coordinates (lat and lng) are all equal to 0.000. This causes the 'moveend' event to fire multiple times and which puts the digest in an infinite loop with the watcher on bounds.
